### PR TITLE
Fix unintended behavior in CubismJson when accessing an index out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+* Fix return correct error values for out-of-index arguments in cubismjson.
+
 
 ## [4-r.3] - 2021-06-10
 

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -8,6 +8,7 @@
 import { CubismIdHandle } from '../id/cubismid';
 import { CubismFramework } from '../live2dcubismframework';
 import { csmString } from '../type/csmstring';
+import { csmVector } from '../type/csmvector';
 import { CubismJson } from '../utils/cubismjson';
 
 // JSON keys
@@ -225,12 +226,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeInTime(curveIndex: number): boolean {
-    return !this._json
+    const value = this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeInTime)
-      .isNull();
+      .getValueByString(FadeInTime);
+    return !(value.isNull() || value.isError());
   }
 
   /**
@@ -240,12 +241,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeOutTime(curveIndex: number): boolean {
-    return !this._json
+    const value = this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeOutTime)
-      .isNull();
+      .getValueByString(FadeOutTime);
+    return !(value.isNull() || value.isError());
   }
 
   /**
@@ -287,7 +288,7 @@ export class CubismMotionJson {
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
       .getValueByString(Segments)
-      .getVector()
+      .getVector(new csmVector())
       .getSize();
   }
 

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -8,7 +8,6 @@
 import { CubismIdHandle } from '../id/cubismid';
 import { CubismFramework } from '../live2dcubismframework';
 import { csmString } from '../type/csmstring';
-import { csmVector } from '../type/csmvector';
 import { CubismJson } from '../utils/cubismjson';
 
 // JSON keys
@@ -226,12 +225,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeInTime(curveIndex: number): boolean {
-    const value = this._json
+    return !this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeInTime);
-    return !(value.isNull() || value.isError());
+      .getValueByString(FadeInTime)
+      .isNull();
   }
 
   /**
@@ -241,12 +240,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeOutTime(curveIndex: number): boolean {
-    const value = this._json
+    return !this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeOutTime);
-    return !(value.isNull() || value.isError());
+      .getValueByString(FadeOutTime)
+      .isNull();
   }
 
   /**
@@ -288,7 +287,7 @@ export class CubismMotionJson {
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
       .getValueByString(Segments)
-      .getVector(new csmVector())
+      .getVector()
       .getSize();
   }
 

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -74,7 +74,7 @@ export abstract class Value {
   /**
    * 要素をコンテナで返す(array)
    */
-  public getVector(defaultValue?: csmVector<Value>): csmVector<Value> {
+  public getVector(defaultValue = new csmVector<Value>()): csmVector<Value> {
     return defaultValue;
   }
 
@@ -192,11 +192,8 @@ export abstract class Value {
   public static staticInitializeNotForClientCall(): void {
     JsonBoolean.trueValue = new JsonBoolean(true);
     JsonBoolean.falseValue = new JsonBoolean(false);
-
-    JsonError.errorValue = new JsonError('ERROR', true);
-    this.nullValue = new JsonNullvalue();
-    this.errorValue = new JsonError('ERROR', true);
-
+    Value.errorValue = new JsonError('ERROR', true);
+    Value.nullValue = new JsonNullvalue();
     Value.s_dummyKeys = new csmVector<string>();
   }
 
@@ -206,13 +203,7 @@ export abstract class Value {
   public static staticReleaseNotForClientCall(): void {
     JsonBoolean.trueValue = null;
     JsonBoolean.falseValue = null;
-    JsonError.errorValue = null;
-    Value.nullValue = null;
-    Value.s_dummyKeys = null;
-
-    JsonBoolean.trueValue = null;
-    JsonBoolean.falseValue = null;
-    JsonError.errorValue = null;
+    Value.errorValue = null;
     Value.nullValue = null;
     Value.s_dummyKeys = null;
   }
@@ -969,6 +960,14 @@ export class JsonNullvalue extends Value {
    */
   public isStatic(): boolean {
     return true;
+  }
+
+  /**
+   * Valueにエラー値をセットする
+   */
+  public setErrorNotForClientCall(s: string): Value {
+    this._stringBuffer = s;
+    return JsonError.nullValue;
   }
 
   /**

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -195,6 +195,7 @@ export abstract class Value {
 
     JsonError.errorValue = new JsonError('ERROR', true);
     this.nullValue = new JsonNullvalue();
+    this.errorValue = new JsonError('ERROR', true);
 
     Value.s_dummyKeys = new csmVector<string>();
   }


### PR DESCRIPTION
I found a issue about `CubismMotionJson` when I was testing PR bellow.

https://github.com/Live2D/CubismWebFramework/pull/8

### Reproduction

1. Build framework code
    ```shell
    npm run build
    ```
2. Create test code
    <details><summary>index.test.js</summary>

    ```js
    const { Value } = require("./dist/utils/cubismjson.js");
    const { CubismMotionJson } = require("./dist/motion/cubismmotionjson.js");

    const motion3json = {
      Version: 3,
      Meta: {
        Duration: 1,
        Fps: 120,
        CurveCount: 3,
        TotalSegmentCount: 3,
        TotalPointCount: 6
      },
      Curves: [
        {
          Target: "PartOpacity",
          Id: "ArmL",
          Segments: [0]
        }
      ]
    };

    const buffer = Uint8Array.from(JSON.stringify(motion3json), c =>
      c.charCodeAt(0)
    ).buffer;
    const cubismMotionJson = new CubismMotionJson(buffer, buffer.byteLength);

    // Initialize Value
    Value.staticInitializeNotForClientCall();

    const invalidIndex = -1; // index out of bounds

    test('Validate "isExistMotionCurveFadeInTime"', () => {
      const actual = cubismMotionJson.isExistMotionCurveFadeInTime(invalidIndex);
      expect(actual).toBe(false);
    });

    test('Validate "isExistMotionCurveFadeOutTime"', () => {
      const actual = cubismMotionJson.isExistMotionCurveFadeInTime(invalidIndex);
      expect(actual).toBe(false);
    });

    test('Validate "getMotionCurveSegmentCount"', () => {
      const actual = cubismMotionJson.getMotionCurveSegmentCount(invalidIndex);
      expect(actual).toBe(0);
    });
    ```
    </details>
3. Run test via command bellow
    ```shell
    npx jest
    ````
4. Test is failure becasuse of following reasons
    <details><summary>Test result</summary>

    ```log
    FAIL  ./index.test.js
      ✕ Validate "isExistMotionCurveFadeInTime" (1 ms)
      ✕ Validate "isExistMotionCurveFadeOutTime" (1 ms)
      ✕ Validate "getMotionCurveSegmentCount" (1 ms)

      ● Validate "isExistMotionCurveFadeInTime"

        TypeError: Cannot read property 'setErrorNotForClientCall' of undefined

          1023 |   public getValueByIndex(index: number): Value {
          1024 |     if (index < 0 || this._array.getSize() <= index) {
        > 1025 |       return Value.errorValue.setErrorNotForClientCall(
               |                               ^
          1026 |         CSM_JSON_ERROR_INDEX_OF_BOUNDS
          1027 |       );
          1028 |     }

          at JsonArray.getValueByIndex (src/utils/cubismjson.ts:1025:31)
          at CubismMotionJson.isExistMotionCurveFadeInTime (src/motion/cubismmotionjson.ts:231:8)
          at Object.<anonymous> (index.test.js:31:35)

      ● Validate "isExistMotionCurveFadeOutTime"

        TypeError: Cannot read property 'setErrorNotForClientCall' of undefined

          1023 |   public getValueByIndex(index: number): Value {
          1024 |     if (index < 0 || this._array.getSize() <= index) {
        > 1025 |       return Value.errorValue.setErrorNotForClientCall(
               |                               ^
          1026 |         CSM_JSON_ERROR_INDEX_OF_BOUNDS
          1027 |       );
          1028 |     }

          at JsonArray.getValueByIndex (src/utils/cubismjson.ts:1025:31)
          at CubismMotionJson.isExistMotionCurveFadeInTime (src/motion/cubismmotionjson.ts:231:8)
          at Object.<anonymous> (index.test.js:36:35)

      ● Validate "getMotionCurveSegmentCount"

        TypeError: Cannot read property 'setErrorNotForClientCall' of undefined

          1023 |   public getValueByIndex(index: number): Value {
          1024 |     if (index < 0 || this._array.getSize() <= index) {
        > 1025 |       return Value.errorValue.setErrorNotForClientCall(
               |                               ^
          1026 |         CSM_JSON_ERROR_INDEX_OF_BOUNDS
          1027 |       );
          1028 |     }

          at JsonArray.getValueByIndex (src/utils/cubismjson.ts:1025:31)
          at CubismMotionJson.getMotionCurveSegmentCount (src/motion/cubismmotionjson.ts:288:8)
          at Object.<anonymous> (index.test.js:41:35)

    Test Suites: 1 failed, 1 total
    Tests:       3 failed, 3 total
    Snapshots:   0 total
    Time:        0.813 s, estimated 2 s
    ```
    </details>

### Repairing

```log
TypeError: Cannot read property 'setErrorNotForClientCall' of undefined
```

This error is caused by `Value.errorValue` property is unset.

So, I change initial value in `Value.staticInitializeNotForClientCall` method for reparing. (This method is called by Framework)

```diff
  public static staticInitializeNotForClientCall(): void {
    JsonBoolean.trueValue = new JsonBoolean(true);
    JsonBoolean.falseValue = new JsonBoolean(false);

-   JsonError.errorValue = new JsonError('ERROR', true);
-   this.nullValue = new JsonNullvalue();
+   Value.errorValue = new JsonError('ERROR', true);
+   Value.nullValue = new JsonNullvalue();

    Value.s_dummyKeys = new csmVector<string>();
  }
```

Note that static property `errorValue` and `nullValue` is defined in only `Value` class.

Now let's run the modified test.

```shell
npm run build && npx jest
```

Oops! I found other issues.

<details><summary>Test result</summary>

```log
 FAIL  ./index.test.js
  ✕ Validate "isExistMotionCurveFadeInTime" (3 ms)
  ✕ Validate "isExistMotionCurveFadeOutTime"
  ✕ Validate "getMotionCurveSegmentCount"

  ● Validate "isExistMotionCurveFadeInTime"

    expect(received).toBe(expected) // Object.is equality

    Expected: false
    Received: true

      32 | test('Validate "isExistMotionCurveFadeInTime"', () => {
      33 |   const actual = cubismMotionJson.isExistMotionCurveFadeInTime(invalidIndex);
    > 34 |   expect(actual).toBe(false);
         |                  ^
      35 | });
      36 |
      37 | test('Validate "isExistMotionCurveFadeOutTime"', () => {

      at Object.<anonymous> (index.test.js:34:18)

  ● Validate "isExistMotionCurveFadeOutTime"

    expect(received).toBe(expected) // Object.is equality

    Expected: false
    Received: true

      37 | test('Validate "isExistMotionCurveFadeOutTime"', () => {
      38 |   const actual = cubismMotionJson.isExistMotionCurveFadeInTime(invalidIndex);
    > 39 |   expect(actual).toBe(false);
         |                  ^
      40 | });
      41 |
      42 | test('Validate "getMotionCurveSegmentCount"', () => {

      at Object.<anonymous> (index.test.js:39:18)

  ● Validate "getMotionCurveSegmentCount"

    TypeError: Cannot read property 'getSize' of undefined

      283 |    */
      284 |   public getMotionCurveSegmentCount(curveIndex: number): number {
    > 285 |     return this._json
          |            ^
      286 |       .getRoot()
      287 |       .getValueByString(Curves)
      288 |       .getValueByIndex(curveIndex)

      at CubismMotionJson.getMotionCurveSegmentCount (src/motion/cubismmotionjson.ts:285:12)
      at Object.<anonymous> (index.test.js:43:35)

Test Suites: 1 failed, 1 total
Tests:       3 failed, 3 total
Snapshots:   0 total
Time:        0.398 s, estimated 1 s
```
</details>

There are two issues.

- `isExistMotionCurveFadeInTime` and `isExistMotionCurveFadeOutTime` returns `true` when call with index out of bounds.
- `getMotionCurveSegmentCount` cannot call `getSize` method because `getVector` returns `undefined` variable.

The cause of the first issue is `JsonError#getValueByString` returns `JsonError`.

```ts
// In CubismMotionJson class
public isExistMotionCurveFadeOutTime(curveIndex: number): boolean {
  return !this._json
    .getRoot()
    .getValueByString(Curves)
    .getValueByIndex(curveIndex) // Returns JsonError instance when call with index out of bounds.
    .getValueByString(FadeOutTime) // Expect to return JsonNullvalue but actual returns JsonError!
    .isNull();
}
```

`JsonError#getValueByString` should return `JsonNullValue`, but actually returns `JsonError`.

```ts
// In JsonError class
public getValueByString(s: string | csmString): Value {
  return Value.nullValue.setErrorNotForClientCall(
    CSM_JSON_ERROR_TYPE_MISMATCH
  ); // Should return JsonNullValue
}
```

This is caused by `JsonNullValue#setErrorNotForClientCall` is not implemented and its implementaion is inherited from `Value#setErrorNotForClientCall`.

```ts
// In Value class
public setErrorNotForClientCall(errorStr: string): Value {
  return JsonError.errorValue; // Returns JsonError by default.
}
```

So, I implement `JsonNullValue#setErrorNotForClientCall` method which returns `JsonNullValue`.

```ts
// In JsonNullValue class
public setErrorNotForClientCall(s: string): Value {
  this._stringBuffer = s;
  return JsonError.nullValue;
}
```

Then, the cause of the second issue is `JsonError#getVector` returns `undefined`.

The implementation of `JsonError#getVector` is in `Value#getVector`, so I change it to return empty csmVector values.

```diff
- public getVector(defaultValue?: csmVector<Value>): csmVector<Value> {
+ public getVector(defaultValue = new csmVector<Value>()): csmVector<Value> {
    return defaultValue;
  }
```

Then `JsonError#getVector#getSize` returns `0` value.

Finally all test case passed!

<details><summary>Test result</summary>

```log
 PASS  ./index.test.js
  ✓ Validate "isExistMotionCurveFadeInTime" (2 ms)
  ✓ Validate "isExistMotionCurveFadeOutTime" (1 ms)
  ✓ Validate "getMotionCurveSegmentCount"

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.284 s, estimated 1 s
```
</details>

I think there are other issues in `CubismJson` class, but I fixed these issues first of all.