### PR TITLE
Update to Cubism SDK for Web R4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+* Fix return correct error values for out-of-index arguments in cubismjson.
+
 
 ## [4-r.3] - 2021-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [4-r.4] - 2021-12-09
 
 ### Fixed
 
-* Fix return correct error values for out-of-index arguments in cubismjson.
+* Fix useless void 0.
+* Fix a warning when `SegmentType` could not be obtained when loading motion.
+* Fix return correct error values for out-of-index arguments in cubismjson by [@cocor-au-lait](https://github.com/cocor-au-lait).
+* Fix a bug that motions currently played do not fade out when play a motion.
 
 
 ## [4-r.3] - 2021-06-10
@@ -63,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Reformat code using Prettier and ESLint.
 
 
+[4-r.4]: https://github.com/Live2D/CubismWebFramework/compare/4-r.3...4-r.4
 [4-r.3]: https://github.com/Live2D/CubismWebFramework/compare/4-r.3-beta.1...4-r.3
 [4-r.3-beta.1]: https://github.com/Live2D/CubismWebFramework/compare/4-r.2...4-r.3-beta.1
 [4-r.2]: https://github.com/Live2D/CubismWebFramework/compare/4-r.1...4-r.2

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利
 
 ### Node.js
 
-* 16.1.0
-* 14.17.0
-* 12.22.1
+* 17.2.0
+* 16.13.1
+* 14.18.2
+* 12.22.7
 
 ### TypeScript
 
-4.2.2
+4.5.2
 
 
 ## 開発環境構築
@@ -132,3 +133,11 @@ JSONパーサーやログ出力などのユーティリティ機能を提供し�
 ## 変更履歴
 
 当リポジトリの変更履歴については [CHANGELOG.md](CHANGELOG.md) を参照ください。
+
+
+## コミュニティ
+
+ユーザー同士でCubism SDKの活用方法の提案や質問をしたい場合は、是非コミュニティをご活用ください。
+
+- [Live2D 公式コミュニティ](https://creatorsforum.live2d.com/)
+- [Live2D community(English)](http://community.live2d.com/)

--- a/src/motion/acubismmotion.ts
+++ b/src/motion/acubismmotion.ts
@@ -26,7 +26,6 @@ export abstract class ACubismMotion {
    */
   public static delete(motion: ACubismMotion): void {
     motion.release();
-    motion = void 0;
     motion = null;
   }
 

--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -11,7 +11,11 @@ import { CubismMath } from '../math/cubismmath';
 import { CubismModel } from '../model/cubismmodel';
 import { csmString } from '../type/csmstring';
 import { csmVector } from '../type/csmvector';
-import { CSM_ASSERT, CubismLogDebug } from '../utils/cubismdebug';
+import {
+  CSM_ASSERT,
+  CubismLogDebug,
+  CubismLogWarning
+} from '../utils/cubismdebug';
 import { ACubismMotion, FinishedMotionCallback } from './acubismmotion';
 import {
   CubismMotionCurve,
@@ -783,6 +787,10 @@ export class CubismMotion extends ACubismMotion {
       ) {
         this._motionData.curves.at(curveCount).type =
           CubismMotionCurveTarget.CubismMotionCurveTarget_PartOpacity;
+      } else {
+        CubismLogWarning(
+          'Warning : Unable to get segment type from Curve! The number of "CurveCount" may be incorrect!'
+        );
       }
 
       this._motionData.curves.at(curveCount).id = json.getMotionCurveId(

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -8,6 +8,7 @@
 import { CubismIdHandle } from '../id/cubismid';
 import { CubismFramework } from '../live2dcubismframework';
 import { csmString } from '../type/csmstring';
+import { csmVector } from '../type/csmvector';
 import { CubismJson } from '../utils/cubismjson';
 
 // JSON keys
@@ -225,12 +226,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeInTime(curveIndex: number): boolean {
-    return !this._json
+    const value = this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeInTime)
-      .isNull();
+      .getValueByString(FadeInTime);
+    return !(value.isNull() || value.isError());
   }
 
   /**
@@ -240,12 +241,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeOutTime(curveIndex: number): boolean {
-    return !this._json
+    const value = this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeOutTime)
-      .isNull();
+      .getValueByString(FadeOutTime);
+    return !(value.isNull() || value.isError());
   }
 
   /**
@@ -287,7 +288,7 @@ export class CubismMotionJson {
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
       .getValueByString(Segments)
-      .getVector()
+      .getVector(new csmVector())
       .getSize();
   }
 

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -8,7 +8,6 @@
 import { CubismIdHandle } from '../id/cubismid';
 import { CubismFramework } from '../live2dcubismframework';
 import { csmString } from '../type/csmstring';
-import { csmVector } from '../type/csmvector';
 import { CubismJson } from '../utils/cubismjson';
 
 // JSON keys
@@ -226,12 +225,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeInTime(curveIndex: number): boolean {
-    const value = this._json
+    return !this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeInTime);
-    return !(value.isNull() || value.isError());
+      .getValueByString(FadeInTime)
+      .isNull();
   }
 
   /**
@@ -241,12 +240,12 @@ export class CubismMotionJson {
    * @return false 存在しない
    */
   public isExistMotionCurveFadeOutTime(curveIndex: number): boolean {
-    const value = this._json
+    return !this._json
       .getRoot()
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
-      .getValueByString(FadeOutTime);
-    return !(value.isNull() || value.isError());
+      .getValueByString(FadeOutTime)
+      .isNull();
   }
 
   /**
@@ -288,7 +287,7 @@ export class CubismMotionJson {
       .getValueByString(Curves)
       .getValueByIndex(curveIndex)
       .getValueByString(Segments)
-      .getVector(new csmVector())
+      .getVector()
       .getSize();
   }
 

--- a/src/motion/cubismmotionqueueentry.ts
+++ b/src/motion/cubismmotionqueueentry.ts
@@ -215,7 +215,7 @@ export class CubismMotionQueueEntry {
    * @return フェードアウト開始するかどうか
    */
   public isTriggeredFadeOut(): boolean {
-    return this._isTriggeredFadeOut && this._endTimeSeconds < 0.0;
+    return this._isTriggeredFadeOut;
   }
 
   /**

--- a/src/motion/cubismmotionqueuemanager.ts
+++ b/src/motion/cubismmotionqueuemanager.ts
@@ -38,7 +38,6 @@ export class CubismMotionQueueManager {
     for (let i = 0; i < this._motions.getSize(); ++i) {
       if (this._motions.at(i)) {
         this._motions.at(i).release();
-        this._motions.set(i, void 0);
         this._motions.set(i, null);
       }
     }
@@ -111,7 +110,6 @@ export class CubismMotionQueueManager {
 
       if (motion == null) {
         motionQueueEntry.release();
-        motionQueueEntry = void 0;
         motionQueueEntry = null;
         ite = this._motions.erase(ite); // 削除
         continue;
@@ -137,7 +135,6 @@ export class CubismMotionQueueManager {
   public isFinishedByHandle(
     motionQueueEntryNumber: CubismMotionQueueEntryHandle
   ): boolean {
-    // 既にモーションがあれば終了フラグを立てる
     for (
       let ite: iterator<CubismMotionQueueEntry> = this._motions.begin();
       ite.notEqual(this._motions.end());
@@ -181,7 +178,6 @@ export class CubismMotionQueueManager {
 
       // ----- 終了済みの処理があれば削除する ------
       motionQueueEntry.release();
-      motionQueueEntry = void 0;
       motionQueueEntry = null;
       ite = this._motions.erase(ite); // 削除
     }
@@ -198,7 +194,6 @@ export class CubismMotionQueueManager {
     motionQueueEntryNumber: any
   ): CubismMotionQueueEntry {
     //------- 処理を行う -------
-    // 既にモーションがあれば終了フラグを立てる
     for (
       let ite: iterator<CubismMotionQueueEntry> = this._motions.begin();
       ite.notEqual(this._motions.end());
@@ -262,7 +257,6 @@ export class CubismMotionQueueManager {
 
       if (motion == null) {
         motionQueueEntry.release();
-        motionQueueEntry = void 0;
         motionQueueEntry = null;
         ite = this._motions.erase(ite); // 削除
 
@@ -289,7 +283,6 @@ export class CubismMotionQueueManager {
       // ------ 終了済みの処理があれば削除する ------
       if (motionQueueEntry.isFinished()) {
         motionQueueEntry.release();
-        motionQueueEntry = void 0;
         motionQueueEntry = null;
         ite = this._motions.erase(ite); // 削除
       } else {

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -74,7 +74,7 @@ export abstract class Value {
   /**
    * 要素をコンテナで返す(array)
    */
-  public getVector(defaultValue?: csmVector<Value>): csmVector<Value> {
+  public getVector(defaultValue = new csmVector<Value>()): csmVector<Value> {
     return defaultValue;
   }
 
@@ -192,11 +192,8 @@ export abstract class Value {
   public static staticInitializeNotForClientCall(): void {
     JsonBoolean.trueValue = new JsonBoolean(true);
     JsonBoolean.falseValue = new JsonBoolean(false);
-
-    JsonError.errorValue = new JsonError('ERROR', true);
-    this.nullValue = new JsonNullvalue();
-    this.errorValue = new JsonError('ERROR', true);
-
+    Value.errorValue = new JsonError('ERROR', true);
+    Value.nullValue = new JsonNullvalue();
     Value.s_dummyKeys = new csmVector<string>();
   }
 
@@ -206,13 +203,7 @@ export abstract class Value {
   public static staticReleaseNotForClientCall(): void {
     JsonBoolean.trueValue = null;
     JsonBoolean.falseValue = null;
-    JsonError.errorValue = null;
-    Value.nullValue = null;
-    Value.s_dummyKeys = null;
-
-    JsonBoolean.trueValue = null;
-    JsonBoolean.falseValue = null;
-    JsonError.errorValue = null;
+    Value.errorValue = null;
     Value.nullValue = null;
     Value.s_dummyKeys = null;
   }
@@ -969,6 +960,14 @@ export class JsonNullvalue extends Value {
    */
   public isStatic(): boolean {
     return true;
+  }
+
+  /**
+   * Valueにエラー値をセットする
+   */
+  public setErrorNotForClientCall(s: string): Value {
+    this._stringBuffer = s;
+    return JsonError.nullValue;
   }
 
   /**

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -195,6 +195,7 @@ export abstract class Value {
 
     JsonError.errorValue = new JsonError('ERROR', true);
     this.nullValue = new JsonNullvalue();
+    this.errorValue = new JsonError('ERROR', true);
 
     Value.s_dummyKeys = new csmVector<string>();
   }


### PR DESCRIPTION
### Fixed

* Fix useless void 0.
* Fix a warning when `SegmentType` could not be obtained when loading motion.
* Fix return correct error values for out-of-index arguments in cubismjson by [@cocor-au-lait](https://github.com/cocor-au-lait).
* Fix a bug that motions currently played do not fade out when play a motion.