### PR TITLE
Fixed a bug where the `PartOpacity` property did not work properly

### DIFF
--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -331,7 +331,7 @@ export class CubismMotion extends ACubismMotion {
               this._fadeOutSeconds
           );
     let value: number;
-    let c: number, parameterIndex: number;
+    let c: number, parameterIndex: number, partIndex: number;
 
     // 'Repeat' time as necessary.
     let time: number = timeOffsetSeconds;
@@ -514,18 +514,18 @@ export class CubismMotion extends ACubismMotion {
         CubismMotionCurveTarget.CubismMotionCurveTarget_PartOpacity;
       ++c
     ) {
-      // Find parameter index.
-      parameterIndex = model.getParameterIndex(curves.at(c).id);
+      // Find part index.
+      partIndex = model.getPartIndex(curves.at(c).id);
 
       // Skip curve evaluation if no value in sink.
-      if (parameterIndex == -1) {
+      if (partIndex == -1) {
         continue;
       }
 
       // Evaluate curve and apply value.
       value = evaluateCurve(this._motionData, c, time);
 
-      model.setParameterValueByIndex(parameterIndex, value);
+      model.setPartOpacityByIndex(partIndex, value);
     }
 
     if (timeOffsetSeconds >= this._motionData.duration) {


### PR DESCRIPTION
`PartOpacity` in the `*.motion3.json` file is treated as  `parameter` ,which could cause a  wrong perform