### PR TITLE
Cubism 4 SDK for Web R5 beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [4-r.5-beta.3] - 2022-06-16
+
+### Fixed
+
+* `getDrawableTextureIndices` function in `CubismModel` has been renamed to `getDrawableTextureIndex` because the name was not correct.
+  * `getDrawableTextureIndices` function is marked as deprecated.
+* Fix physics system behaviour when exists Physics Fps Setting in .physics3.json.
+
 
 ## [4-r.5-beta.2] - 2022-06-02
 
@@ -89,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Reformat code using Prettier and ESLint.
 
 
+[4-r.5-beta.3]: https://github.com/Live2D/CubismWebFramework/compare/4-r.5-beta.2...4-r.5-beta.3
 [4-r.5-beta.2]: https://github.com/Live2D/CubismWebFramework/compare/4-r.5-beta.1...4-r.5-beta.2
 [4-r.5-beta.1]: https://github.com/Live2D/CubismWebFramework/compare/4-r.4...4-r.5-beta.1
 [4-r.4]: https://github.com/Live2D/CubismWebFramework/compare/4-r.3...4-r.4

--- a/src/model/cubismmodel.ts
+++ b/src/model/cubismmodel.ts
@@ -646,11 +646,23 @@ export class CubismModel {
   }
 
   /**
+   * @deprecated
+   * 関数名が誤っていたため、代替となる getDrawableTextureIndex を追加し、この関数は非推奨となりました。
+   *
    * Drawableのテクスチャインデックスリストの取得
    * @param drawableIndex Drawableのインデックス
    * @return drawableのテクスチャインデックスリスト
    */
   public getDrawableTextureIndices(drawableIndex: number): number {
+    return this.getDrawableTextureIndex(drawableIndex);
+  }
+
+  /**
+   * Drawableのテクスチャインデックスの取得
+   * @param drawableIndex Drawableのインデックス
+   * @return drawableのテクスチャインデックス
+   */
+  public getDrawableTextureIndex(drawableIndex: number): number {
     const textureIndices: Int32Array = this._model.drawables.textureIndices;
     return textureIndices[drawableIndex];
   }

--- a/src/physics/cubismphysicsinternal.ts
+++ b/src/physics/cubismphysicsinternal.ts
@@ -208,6 +208,7 @@ export class CubismPhysicsRig {
     this.particles = new csmVector<CubismPhysicsParticle>();
     this.gravity = new CubismVector2(0, 0);
     this.wind = new CubismVector2(0, 0);
+    this.fps = 0.0;
   }
 
   subRigCount: number; // 物理演算の物理点の個数
@@ -217,6 +218,7 @@ export class CubismPhysicsRig {
   particles: csmVector<CubismPhysicsParticle>; // 物理演算の物理点のリスト
   gravity: CubismVector2; // 重力
   wind: CubismVector2; // 風
+  fps: number; //物理演算動作FPS
 }
 
 // Namespace definition for compatibility.

--- a/src/physics/cubismphysicsjson.ts
+++ b/src/physics/cubismphysicsjson.ts
@@ -27,6 +27,7 @@ const PhysicsSettingCount = 'PhysicsSettingCount';
 const Gravity = 'Gravity';
 const Wind = 'Wind';
 const VertexCount = 'VertexCount';
+const Fps = 'Fps';
 
 // PhysicsSettings
 const PhysicsSettings = 'PhysicsSettings';
@@ -118,6 +119,18 @@ export class CubismPhysicsJson {
       .getValueByString(Y)
       .toFloat();
     return ret;
+  }
+
+  /**
+   * 物理演算設定FPSの取得
+   * @return 物理演算設定FPS
+   */
+  public getFps(): number {
+    return this._json
+      .getRoot()
+      .getValueByString(Meta)
+      .getValueByString(Fps)
+      .toFloat(0.0);
   }
 
   /**

--- a/src/rendering/cubismrenderer_webgl.ts
+++ b/src/rendering/cubismrenderer_webgl.ts
@@ -502,7 +502,7 @@ export class CubismClippingManager_WebGL {
           // チャンネルも切り替える必要がある(A,R,G,B)
           renderer.setClippingContextBufferForMask(clipContext);
           renderer.drawMesh(
-            model.getDrawableTextureIndices(clipDrawIndex),
+            model.getDrawableTextureIndex(clipDrawIndex),
             model.getDrawableVertexIndexCount(clipDrawIndex),
             model.getDrawableVertexCount(clipDrawIndex),
             model.getDrawableVertexIndices(clipDrawIndex),
@@ -2115,7 +2115,7 @@ export class CubismRenderer_WebGL extends CubismRenderer {
       this.setIsCulling(this.getModel().getDrawableCulling(drawableIndex));
 
       this.drawMesh(
-        this.getModel().getDrawableTextureIndices(drawableIndex),
+        this.getModel().getDrawableTextureIndex(drawableIndex),
         this.getModel().getDrawableVertexIndexCount(drawableIndex),
         this.getModel().getDrawableVertexCount(drawableIndex),
         this.getModel().getDrawableVertexIndices(drawableIndex),


### PR DESCRIPTION
### Fixed

* `getDrawableTextureIndices` function in `CubismModel` has been renamed to `getDrawableTextureIndex` because the name was not correct.
  * `getDrawableTextureIndices` function is marked as deprecated.
* Fix physics system behaviour when exists Physics Fps Setting in .physics3.json.