### PR TITLE
Update to Cubism 5 SDK for Web R1 beta1

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,6 +15,7 @@ rules:
   prettier/prettier:
     - error
     - singleQuote: true
+      trailingComma: none
   camelcase: "off"
   '@typescript-eslint/naming-convention':
     - warn
@@ -58,6 +59,8 @@ rules:
   '@typescript-eslint/no-unsafe-member-access': off
   '@typescript-eslint/no-unsafe-argument': off
   '@typescript-eslint/no-unsafe-call': off
+  '@typescript-eslint/no-explicit-any': off
+  '@typescript-eslint/no-unused-vars': off
   'no-inner-declarations': off
   'no-global-assign': off
   'prefer-const': warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [5-r.1-beta.1] - 2023-08-17
+
+### Added
+
+* Add the function to get the ID of a given parameter.(`CubismModel.getParameterId`)
+* Add the `CubismExpressionMotionManager` class.
+
+### Changed
+
+* Change the visibility of the `CubismId` constructor to private.
+  * Please use `CubismFramework.getIdManager().getId()` to get `CubismId`.
+* Change the word `DrawMesh` to `DrawMeshWebGL`.
+
+### Fixed
+
+* Fix a bug that the value applied by multiply was not appropriate during expression transitions.
+* Fix the structure of the class in renderer.
+* Fix a issue where `ARRAY_BUFFER` was used on multiple targets.
+* Separate shader class from `cubismrenderer` class.
+* Separate the high precision mask process from the clipping mask setup process.
+
+### Removed
+
+* Remove several arguments of `DrawMesh` function.
+
+
 ## [4-r.7] - 2023-05-25
 
 ### Added
@@ -182,6 +208,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Reformat code using Prettier and ESLint.
 
 
+[5-r.1-beta.1]: https://github.com/Live2D/CubismWebFramework/compare/4-r.7...5-r.1-beta.1
 [4-r.7]: https://github.com/Live2D/CubismWebFramework/compare/4-r.6.2...4-r.7
 [4-r.6.2]: https://github.com/Live2D/CubismWebFramework/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismWebFramework/compare/4-r.6...4-r.6.1

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 
 # Cubism Web Framework
 
-Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利用するためのフレームワークです。
+Live2D Cubism Editor で出力したモデルをアプリケーションで利用するためのフレームワークです。
 
 モデルを表示、操作するための各種機能を提供します。
 モデルをロードするには Live2D Cubism Core ライブラリと組み合わせて使用します。
@@ -17,18 +17,27 @@ Live2D Cubism 4 Editor で出力したモデルをアプリケーションで利
 本 SDK を使用する前に、[ライセンス](LICENSE.md)をご確認ください。
 
 
+## Cubism 5新機能や過去バージョンとの互換性について
+
+本 SDK はCubism 5に対応した製品です。
+
+Cubism 5 Editorに搭載された新機能のSDK対応については [こちら](https://docs.live2d.com/cubism-sdk-manual/cubism-5-new-functions/)をご確認ください。
+
+過去バージョンのCubism SDKとの互換性については [こちら](https://docs.live2d.com/cubism-sdk-manual/compatibility-with-cubism-5/)をご確認ください。
+
+
 ## 開発環境
 
 ### Node.js
 
-* 20.1.0
-* 18.16.0
-* 16.20.0
+* 20.5.1
+* 18.17.1
+* 16.20.2
 
 
 ### TypeScript
 
-5.0.4
+5.1.6
 
 
 ## 開発環境構築

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Cubism Web Framework
 
-This is a framework for using models output by Live2D Cubism 4 Editor in applications.
+This is a framework for using models output by Live2D Cubism Editor in applications.
 
 It provides various functions for displaying and manipulating the model.
 It is used in conjunction with the Live2D Cubism Core library to load the model.
@@ -17,17 +17,26 @@ You can use it as a JavaScript library that can be used in the browser by buildi
 Please check the [license](LICENSE.md) before using this SDK.
 
 
+## Compatibility with Cubism 5 new features and previous Cubism SDK versions
+
+This SDK is compatible with Cubism 5.
+
+For SDK compatibility with new features in Cubism 5 Editor, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/cubism-5-new-functions/).
+
+For compatibility with previous versions of Cubism SDK, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/compatibility-with-cubism-5/).
+
+
 ## Development environment
 
 ### Node.js
 
-* 20.1.0
-* 18.16.0
-* 16.20.0
+* 20.5.1
+* 18.17.1
+* 16.20.2
 
 ### TypeScript
 
-5.0.4
+5.1.6
 
 
 ## Development environment construction

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,23 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.59.5",
-        "@typescript-eslint/parser": "^5.59.5",
-        "eslint": "^8.40.0",
-        "eslint-config-prettier": "^8.8.0",
-        "eslint-plugin-prettier": "^4.2.1",
-        "prettier": "^2.8.8",
-        "rimraf": "^5.0.0",
-        "typescript": "^5.0.4"
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
+        "@typescript-eslint/parser": "^6.4.0",
+        "eslint": "^8.47.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-prettier": "^5.0.0",
+        "prettier": "^3.0.1",
+        "rimraf": "^5.0.1",
+        "typescript": "^5.1.6"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -31,23 +40,23 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.2",
+        "espree": "^9.6.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -63,18 +72,18 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
-      "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -134,9 +143,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -193,10 +202,30 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -206,32 +235,33 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.5.tgz",
-      "integrity": "sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/type-utils": "5.59.5",
-        "@typescript-eslint/utils": "5.59.5",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/type-utils": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -240,25 +270,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.5.tgz",
-      "integrity": "sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -267,16 +298,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.5.tgz",
-      "integrity": "sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/visitor-keys": "5.59.5"
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -284,25 +315,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.5.tgz",
-      "integrity": "sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.5",
-        "@typescript-eslint/utils": "5.59.5",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -311,12 +342,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.5.tgz",
-      "integrity": "sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -324,21 +355,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.5.tgz",
-      "integrity": "sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/visitor-keys": "5.59.5",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -351,42 +382,41 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.5.tgz",
-      "integrity": "sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
       "dev": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.5.tgz",
-      "integrity": "sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.5",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.4.0",
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -394,9 +424,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -475,6 +505,27 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -495,6 +546,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/callsites": {
@@ -583,6 +649,52 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -632,27 +744,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
-      "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.40.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -660,22 +772,19 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -689,9 +798,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -701,55 +810,38 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -762,22 +854,25 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
-        "node": ">=4.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
       },
@@ -800,15 +895,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -821,19 +907,10 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -846,6 +923,29 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -861,9 +961,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -999,11 +1099,35 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1038,9 +1162,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1072,10 +1196,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/has-flag": {
@@ -1087,10 +1211,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1137,6 +1270,21 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1167,6 +1315,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1185,6 +1351,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1192,9 +1397,9 @@
       "dev": true
     },
     "node_modules/jackspeak": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.0.tgz",
-      "integrity": "sha512-r5XBrqIJfwRIjRt/Xr5fv9Wh09qyhHfKnYddDlpM+ibRR20qrYActpCAgU6U+d53EOEjzkvxPMVHSlgR7leXrQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.3.tgz",
+      "integrity": "sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -1207,16 +1412,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-yaml": {
@@ -1289,6 +1484,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1311,6 +1512,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1324,12 +1537,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1344,11 +1557,32 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1359,18 +1593,51 @@
         "wrappy": "1"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -1446,13 +1713,13 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.8.0.tgz",
-      "integrity": "sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0"
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1462,9 +1729,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
-      "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -1478,6 +1745,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1501,15 +1774,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -1576,12 +1849,12 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
-      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "dependencies": {
-        "glob": "^10.0.0"
+        "glob": "^10.2.5"
       },
       "bin": {
         "rimraf": "dist/cjs/src/bin.js"
@@ -1603,16 +1876,16 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.3.tgz",
-      "integrity": "sha512-Kb4rfmBVE3eQTAimgmeqc2LwSnN0wIOkkUL6HmxEFxNJ4fHghYHVbFba/HcGcRjE6s9KoMNK3rSOwkL4PioZjg==",
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+      "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.0",
-        "minipass": "^5.0.0",
-        "path-scurry": "^1.7.0"
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -1625,9 +1898,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1637,6 +1910,110 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/run-applescript/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/run-applescript/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-applescript/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/run-applescript/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/run-parallel": {
@@ -1663,9 +2040,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1699,16 +2076,10 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -1770,9 +2141,9 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1809,6 +2180,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1833,11 +2216,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -1851,26 +2262,23 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+    "node_modules/ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
       "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
       "engines": {
-        "node": ">= 6"
+        "node": ">=16.13.0"
       },
       "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+        "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1897,16 +2305,25 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/uri-js": {
@@ -1931,15 +2348,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -2022,9 +2430,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -2062,6 +2470,12 @@
     }
   },
   "dependencies": {
+    "@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2072,20 +2486,20 @@
       }
     },
     "@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
-      "integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.5.2",
+        "espree": "^9.6.0",
         "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
@@ -2095,15 +2509,15 @@
       }
     },
     "@eslint/js": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
-      "integrity": "sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
-      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -2144,9 +2558,9 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
@@ -2187,10 +2601,24 @@
       "dev": true,
       "optional": true
     },
+    "@pkgr/utils": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
+      "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.3.0",
+        "is-glob": "^4.0.3",
+        "open": "^9.1.0",
+        "picocolors": "^1.0.0",
+        "tslib": "^2.6.0"
+      }
+    },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
     "@types/semver": {
@@ -2200,108 +2628,109 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.5.tgz",
-      "integrity": "sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
       "dev": true,
       "requires": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/type-utils": "5.59.5",
-        "@typescript-eslint/utils": "5.59.5",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/type-utils": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.5.tgz",
-      "integrity": "sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.5.tgz",
-      "integrity": "sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/visitor-keys": "5.59.5"
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.5.tgz",
-      "integrity": "sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.59.5",
-        "@typescript-eslint/utils": "5.59.5",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.5.tgz",
-      "integrity": "sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.5.tgz",
-      "integrity": "sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/visitor-keys": "5.59.5",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.5.tgz",
-      "integrity": "sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
       "dev": true,
       "requires": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.5",
-        "@typescript-eslint/types": "5.59.5",
-        "@typescript-eslint/typescript-estree": "5.59.5",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "semver": "^7.5.4"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.59.5",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.5.tgz",
-      "integrity": "sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.59.5",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.4.0",
+        "eslint-visitor-keys": "^3.4.1"
       }
     },
     "acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -2356,6 +2785,21 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true
+    },
+    "bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.44"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2373,6 +2817,15 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "requires": {
+        "run-applescript": "^5.0.0"
       }
     },
     "callsites": {
@@ -2438,6 +2891,34 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "requires": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      }
+    },
+    "default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "requires": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      }
+    },
+    "define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2475,27 +2956,27 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.40.0.tgz",
-      "integrity": "sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.40.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2503,82 +2984,62 @@
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "globals": "^13.19.0",
-        "grapheme-splitter": "^1.0.4",
+        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
         "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-          "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^5.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "eslint-config-prettier": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
-      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "requires": {}
     },
     "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.0.tgz",
+      "integrity": "sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       }
     },
     "eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "estraverse": "^5.2.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true
     },
     "espree": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
-      "integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "requires": {
-        "acorn": "^8.8.0",
+        "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.4.1"
       }
@@ -2590,14 +3051,6 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "esrecurse": {
@@ -2607,20 +3060,12 @@
       "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
       }
     },
     "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
     "esutils": {
@@ -2628,6 +3073,23 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -2642,9 +3104,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2749,12 +3211,26 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
+      },
+      "dependencies": {
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
     },
     "glob": {
@@ -2781,9 +3257,9 @@
       }
     },
     "globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -2803,10 +3279,10 @@
         "slash": "^3.0.0"
       }
     },
-    "grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "has-flag": {
@@ -2815,10 +3291,16 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true
+    },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "import-fresh": {
@@ -2853,6 +3335,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2874,6 +3362,15 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^3.0.0"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2886,6 +3383,29 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+          "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+          "dev": true
+        }
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2893,20 +3413,14 @@
       "dev": true
     },
     "jackspeak": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.0.tgz",
-      "integrity": "sha512-r5XBrqIJfwRIjRt/Xr5fv9Wh09qyhHfKnYddDlpM+ibRR20qrYActpCAgU6U+d53EOEjzkvxPMVHSlgR7leXrQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.3.tgz",
+      "integrity": "sha512-pF0kfjmg8DJLxDrizHoCZGUFz4P4czQ3HyfW4BU0ffebYkzAVlBywp5zaxW/TM+r0sGbmrQdi8EQQVTJFxnGsQ==",
       "dev": true,
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -2963,6 +3477,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2979,6 +3499,12 @@
         "picomatch": "^2.3.1"
       }
     },
+    "mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2989,9 +3515,9 @@
       }
     },
     "minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
+      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
       "dev": true
     },
     "ms": {
@@ -3006,11 +3532,22 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
+    "npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "requires": {
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        }
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -3021,18 +3558,39 @@
         "wrappy": "1"
       }
     },
-    "optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+    "onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "requires": {
+        "mimic-fn": "^4.0.0"
+      }
+    },
+    "open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "requires": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "requires": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
+        "type-check": "^0.4.0"
       }
     },
     "p-limit": {
@@ -3081,19 +3639,19 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.8.0.tgz",
-      "integrity": "sha512-IjTrKseM404/UAWA8bBbL3Qp6O2wXkanuIE3seCxBH7ctRuvH1QRawy1N3nVDHGkdeZsjOsSe/8AQBL/VQCy2g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0"
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.1.tgz",
-          "integrity": "sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+          "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
           "dev": true
         }
       }
@@ -3102,6 +3660,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {
@@ -3117,9 +3681,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -3156,12 +3720,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.0.tgz",
-      "integrity": "sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
+      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
       "dev": true,
       "requires": {
-        "glob": "^10.0.0"
+        "glob": "^10.2.5"
       },
       "dependencies": {
         "brace-expansion": {
@@ -3174,26 +3738,96 @@
           }
         },
         "glob": {
-          "version": "10.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.3.tgz",
-          "integrity": "sha512-Kb4rfmBVE3eQTAimgmeqc2LwSnN0wIOkkUL6HmxEFxNJ4fHghYHVbFba/HcGcRjE6s9KoMNK3rSOwkL4PioZjg==",
+          "version": "10.3.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.3.tgz",
+          "integrity": "sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
             "jackspeak": "^2.0.3",
-            "minimatch": "^9.0.0",
-            "minipass": "^5.0.0",
-            "path-scurry": "^1.7.0"
+            "minimatch": "^9.0.1",
+            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+            "path-scurry": "^1.10.1"
           }
         },
         "minimatch": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
-          "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        }
+      }
+    },
+    "run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.0",
+            "human-signals": "^2.1.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.1",
+            "onetime": "^5.1.2",
+            "signal-exit": "^3.0.3",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+          "dev": true
         }
       }
     },
@@ -3207,9 +3841,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -3231,9 +3865,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "slash": {
@@ -3260,9 +3894,9 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
@@ -3307,6 +3941,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3322,10 +3962,26 @@
         "has-flag": "^4.0.0"
       }
     },
+    "synckit": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+      "dev": true,
+      "requires": {
+        "@pkgr/utils": "^2.3.1",
+        "tslib": "^2.5.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true
     },
     "to-regex-range": {
@@ -3337,20 +3993,18 @@
         "is-number": "^7.0.0"
       }
     },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
-    },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+    "ts-api-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
+      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
       "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
+      "requires": {}
+    },
+    "tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -3368,9 +4022,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
     "uri-js": {
@@ -3390,12 +4050,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
     },
     "wrap-ansi": {
       "version": "8.1.0",
@@ -3421,9 +4075,9 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.59.5",
-    "@typescript-eslint/parser": "^5.59.5",
-    "eslint": "^8.40.0",
-    "eslint-config-prettier": "^8.8.0",
-    "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.8.8",
-    "rimraf": "^5.0.0",
-    "typescript": "^5.0.4"
+    "@typescript-eslint/eslint-plugin": "^6.4.0",
+    "@typescript-eslint/parser": "^6.4.0",
+    "eslint": "^8.47.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.1",
+    "rimraf": "^5.0.1",
+    "typescript": "^5.1.6"
   }
 }

--- a/src/cubismdefaultparameterid.ts
+++ b/src/cubismdefaultparameterid.ts
@@ -60,7 +60,7 @@ export const CubismDefaultParameterId = Object.freeze<Record<string, string>>({
   ParamBustY: 'ParamBustY',
   ParamBaseX: 'ParamBaseX',
   ParamBaseY: 'ParamBaseY',
-  ParamNONE: 'NONE:',
+  ParamNONE: 'NONE:'
 });
 
 // Namespace definition for compatibility.

--- a/src/cubismmodelsettingjson.ts
+++ b/src/cubismmodelsettingjson.ts
@@ -73,7 +73,7 @@ enum FrequestNode {
   FrequestNode_Textures, // getRoot().getValueByString(FileReferences).getValueByString(Textures)
   FrequestNode_Physics, // getRoot().getValueByString(FileReferences).getValueByString(Physics)
   FrequestNode_Pose, // getRoot().getValueByString(FileReferences).getValueByString(Pose)
-  FrequestNode_HitAreas, // getRoot().getValueByString(HitAreas)
+  FrequestNode_HitAreas // getRoot().getValueByString(HitAreas)
 }
 
 /**

--- a/src/effect/cubismeyeblink.ts
+++ b/src/effect/cubismeyeblink.ts
@@ -219,7 +219,7 @@ export enum EyeState {
   EyeState_Interval, // まばたきしていない状態
   EyeState_Closing, // まぶたが閉じていく途中の状態
   EyeState_Closed, // まぶたが閉じている状態
-  EyeState_Opening, // まぶたが開いていく途中の状態
+  EyeState_Opening // まぶたが開いていく途中の状態
 }
 
 // Namespace definition for compatibility.

--- a/src/id/cubismid.ts
+++ b/src/id/cubismid.ts
@@ -11,25 +11,28 @@ import { csmString } from '../type/csmstring';
  * パラメータ名・パーツ名・Drawable名を保持
  *
  * パラメータ名・パーツ名・Drawable名を保持するクラス。
+ *
+ * @note 指定したID文字列からCubismIdを取得する際はこのクラスの生成メソッドを呼ばず、
+ *       CubismIdManager().getId(id)を使用してください
  */
 export class CubismId {
+  /**
+   * 内部で使用するCubismIdクラス生成メソッド
+   *
+   * @param id ID文字列
+   * @returns CubismId
+   * @note 指定したID文字列からCubismIdを取得する際は
+   *       CubismIdManager().getId(id)を使用してください
+   */
+  public static _createIdInternal(id: string | csmString) {
+    return new CubismId(id);
+  }
+
   /**
    * ID名を取得する
    */
   public getString(): csmString {
     return this._id;
-  }
-
-  /**
-   * コンストラクタ
-   */
-  public constructor(id: string | csmString) {
-    if (typeof id === 'string') {
-      this._id = new csmString(id);
-      return;
-    }
-
-    this._id = id;
   }
 
   /**
@@ -62,6 +65,20 @@ export class CubismId {
       return !this._id.isEqual(c._id.s);
     }
     return false;
+  }
+
+  /**
+   * プライベートコンストラクタ
+   *
+   * @note ユーザーによる生成は許可しません
+   */
+  private constructor(id: string | csmString) {
+    if (typeof id === 'string') {
+      this._id = new csmString(id);
+      return;
+    }
+
+    this._id = id;
   }
 
   private _id: csmString; // ID名

--- a/src/id/cubismidmanager.ts
+++ b/src/id/cubismidmanager.ts
@@ -57,7 +57,7 @@ export class CubismIdManager {
         return result;
       }
 
-      result = new CubismId(id);
+      result = CubismId._createIdInternal(id);
       this._ids.pushBack(result);
     } else {
       return this.registerId(id.s);

--- a/src/live2dcubismframework.ts
+++ b/src/live2dcubismframework.ts
@@ -10,7 +10,7 @@ import { CubismRenderer } from './rendering/cubismrenderer';
 import {
   CSM_ASSERT,
   CubismLogInfo,
-  CubismLogWarning,
+  CubismLogWarning
 } from './utils/cubismdebug';
 import { Value } from './utils/cubismjson';
 
@@ -56,7 +56,7 @@ let s_cubismIdManager: CubismIdManager = null;
  */
 export const Constant = Object.freeze<Record<string, number>>({
   vertexOffset: 0, // メッシュ頂点のオフセット値
-  vertexStep: 2, // メッシュ頂点のステップ値
+  vertexStep: 2 // メッシュ頂点のステップ値
 });
 
 export function csmDelete<T>(address: T): void {
@@ -274,7 +274,7 @@ export enum LogLevel {
   LogLevel_Info, // Infoログ
   LogLevel_Warning, // 警告ログ
   LogLevel_Error, // エラーログ
-  LogLevel_Off, // ログ出力無効
+  LogLevel_Off // ログ出力無効
 }
 
 // Namespace definition for compatibility.

--- a/src/math/cubismmatrix44.ts
+++ b/src/math/cubismmatrix44.ts
@@ -33,7 +33,7 @@ export class CubismMatrix44 {
   ): void {
     const c: Float32Array = new Float32Array([
       0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-      0.0,
+      0.0
     ]);
 
     const n = 4;
@@ -57,7 +57,7 @@ export class CubismMatrix44 {
   public loadIdentity(): void {
     const c: Float32Array = new Float32Array([
       1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-      1.0,
+      1.0
     ]);
 
     this.setMatrix(c);
@@ -175,7 +175,7 @@ export class CubismMatrix44 {
       x,
       y,
       0.0,
-      1.0,
+      1.0
     ]);
 
     CubismMatrix44.multiply(tr1, this._tr, this._tr);
@@ -235,7 +235,7 @@ export class CubismMatrix44 {
       0.0,
       0.0,
       0.0,
-      1.0,
+      1.0
     ]);
 
     CubismMatrix44.multiply(tr1, this._tr, this._tr);

--- a/src/math/cubismvector2.ts
+++ b/src/math/cubismvector2.ts
@@ -14,7 +14,10 @@ export class CubismVector2 {
   /**
    * コンストラクタ
    */
-  public constructor(public x?: number, public y?: number) {
+  public constructor(
+    public x?: number,
+    public y?: number
+  ) {
     this.x = x == undefined ? 0.0 : x;
 
     this.y = y == undefined ? 0.0 : y;

--- a/src/math/cubismviewmatrix.ts
+++ b/src/math/cubismviewmatrix.ts
@@ -72,7 +72,7 @@ export class CubismViewMatrix extends CubismMatrix44 {
       x,
       y,
       0.0,
-      1.0,
+      1.0
     ]);
 
     CubismMatrix44.multiply(tr1, this._tr, this._tr);
@@ -117,7 +117,7 @@ export class CubismViewMatrix extends CubismMatrix44 {
       cx,
       cy,
       0.0,
-      1.0,
+      1.0
     ]);
 
     const tr2: Float32Array = new Float32Array([
@@ -136,7 +136,7 @@ export class CubismViewMatrix extends CubismMatrix44 {
       0.0,
       0.0,
       0.0,
-      1.0,
+      1.0
     ]);
 
     const tr3: Float32Array = new Float32Array([
@@ -155,7 +155,7 @@ export class CubismViewMatrix extends CubismMatrix44 {
       -cx,
       -cy,
       0.0,
-      1.0,
+      1.0
     ]);
 
     CubismMatrix44.multiply(tr3, this._tr, this._tr);

--- a/src/model/cubismmodel.ts
+++ b/src/model/cubismmodel.ts
@@ -9,7 +9,7 @@ import { CubismIdHandle } from '../id/cubismid';
 import { CubismFramework } from '../live2dcubismframework';
 import {
   CubismBlendMode,
-  CubismTextureColor,
+  CubismTextureColor
 } from '../rendering/cubismrenderer';
 import { csmMap } from '../type/csmmap';
 import { csmVector } from '../type/csmvector';
@@ -844,6 +844,18 @@ export class CubismModel {
    */
   public getParameterDefaultValue(parameterIndex: number): number {
     return this._model.parameters.defaultValues[parameterIndex];
+  }
+
+  /**
+   * 指定したパラメータindexのIDを取得
+   *
+   * @param parameterIndex パラメータのインデックス
+   * @returns パラメータID
+   */
+  public getParameterId(parameterIndex: number): CubismIdHandle {
+    return CubismFramework.getIdManager().getId(
+      this._model.parameters.ids[parameterIndex]
+    );
   }
 
   /**

--- a/src/model/cubismusermodel.ts
+++ b/src/model/cubismusermodel.ts
@@ -14,6 +14,7 @@ import { CubismModelMatrix } from '../math/cubismmodelmatrix';
 import { CubismTargetPoint } from '../math/cubismtargetpoint';
 import { ACubismMotion, FinishedMotionCallback } from '../motion/acubismmotion';
 import { CubismExpressionMotion } from '../motion/cubismexpressionmotion';
+import { CubismExpressionMotionManager } from '../motion/cubismexpressionmotionmanager';
 import { CubismMotion } from '../motion/cubismmotion';
 import { CubismMotionManager } from '../motion/cubismmotionmanager';
 import { CubismMotionQueueManager } from '../motion/cubismmotionqueuemanager';
@@ -371,7 +372,7 @@ export class CubismUserModel {
     );
 
     // 表情マネージャーを作成
-    this._expressionManager = new CubismMotionManager();
+    this._expressionManager = new CubismExpressionMotionManager();
 
     // ドラッグによるアニメーション
     this._dragManager = new CubismTargetPoint();
@@ -415,7 +416,7 @@ export class CubismUserModel {
   protected _model: CubismModel; // Modelインスタンス
 
   protected _motionManager: CubismMotionManager; // モーション管理
-  protected _expressionManager: CubismMotionManager; // 表情管理
+  protected _expressionManager: CubismExpressionMotionManager; // 表情管理
   protected _eyeBlink: CubismEyeBlink; // 自動まばたき
   protected _breath: CubismBreath; // 呼吸
   protected _modelMatrix: CubismModelMatrix; // モデル行列

--- a/src/motion/acubismmotion.ts
+++ b/src/motion/acubismmotion.ts
@@ -78,6 +78,38 @@ export abstract class ACubismMotion {
       }
     }
 
+    const fadeWeight = this.updateFadeWeight(motionQueueEntry, userTimeSeconds);
+
+    //---- 全てのパラメータIDをループする ----
+    this.doUpdateParameters(
+      model,
+      userTimeSeconds,
+      fadeWeight,
+      motionQueueEntry
+    );
+
+    // 後処理
+    // 終了時刻を過ぎたら終了フラグを立てる(CubismMotionQueueManager)
+    if (
+      motionQueueEntry.getEndTime() > 0 &&
+      motionQueueEntry.getEndTime() < userTimeSeconds
+    ) {
+      motionQueueEntry.setIsFinished(true); // 終了
+    }
+  }
+
+  /**
+   * @brief モデルのウェイト更新
+   *
+   * モーションのウェイトを更新する。
+   *
+   * @param[in]   motionQueueEntry    CubismMotionQueueManagerで管理されているモーション
+   * @param[in]   userTimeSeconds     デルタ時間の積算値[秒]
+   */
+  public updateFadeWeight(
+    motionQueueEntry: CubismMotionQueueEntry,
+    userTimeSeconds: number
+  ): number {
     let fadeWeight: number = this._weight; // 現在の値と掛け合わせる割合
 
     //---- フェードイン・アウトの処理 ----
@@ -104,22 +136,7 @@ export abstract class ACubismMotion {
 
     CSM_ASSERT(0.0 <= fadeWeight && fadeWeight <= 1.0);
 
-    //---- 全てのパラメータIDをループする ----
-    this.doUpdateParameters(
-      model,
-      userTimeSeconds,
-      fadeWeight,
-      motionQueueEntry
-    );
-
-    // 後処理
-    // 終了時刻を過ぎたら終了フラグを立てる(CubismMotionQueueManager)
-    if (
-      motionQueueEntry.getEndTime() > 0 &&
-      motionQueueEntry.getEndTime() < userTimeSeconds
-    ) {
-      motionQueueEntry.setIsFinished(true); // 終了
-    }
+    return fadeWeight;
   }
 
   /**

--- a/src/motion/cubismexpressionmotionmanager.ts
+++ b/src/motion/cubismexpressionmotionmanager.ts
@@ -1,0 +1,267 @@
+import { CubismId, CubismIdHandle } from '../id/cubismid';
+import { csmDelete } from '../live2dcubismframework';
+import { CubismModel } from '../model/cubismmodel';
+import { csmVector, iterator } from '../type/csmvector';
+import { ACubismMotion } from './acubismmotion';
+import { CubismExpressionMotion } from './cubismexpressionmotion';
+import { CubismMotionQueueEntry } from './cubismmotionqueueentry';
+import {
+  CubismMotionQueueEntryHandle,
+  CubismMotionQueueManager
+} from './cubismmotionqueuemanager';
+
+/**
+ * @brief パラメータに適用する表情の値を持たせる構造体
+ */
+export class ExpressionParameterValue {
+  parameterId: CubismIdHandle; // パラメーターID
+  additiveValue: number; // 加算値
+  multiplyValue: number; // 乗算値
+  overwriteValue: number; // 上書き値
+}
+
+/**
+ * @brief 表情モーションの管理
+ *
+ * 表情モーションの管理をおこなうクラス。
+ */
+export class CubismExpressionMotionManager extends CubismMotionQueueManager {
+  /**
+   * コンストラクタ
+   */
+  public constructor() {
+    super();
+    this._currentPriority = 0;
+    this._reservePriority = 0;
+    this._expressionParameterValues = new csmVector<ExpressionParameterValue>();
+  }
+
+  /**
+   * デストラクタ相当の処理
+   */
+  public release(): void {
+    if (this._expressionParameterValues) {
+      csmDelete(this._expressionParameterValues);
+      this._expressionParameterValues = null;
+    }
+  }
+
+  /**
+   * @brief 再生中のモーションの優先度の取得
+   *
+   * 再生中のモーションの優先度を取得する。
+   *
+   * @returns モーションの優先度
+   */
+  public getCurrentPriority(): number {
+    return this._currentPriority;
+  }
+
+  /**
+   * @brief 予約中のモーションの優先度の取得
+   *
+   * 予約中のモーションの優先度を取得する。
+   *
+   * @return  モーションの優先度
+   */
+  public getReservePriority(): number {
+    return this._reservePriority;
+  }
+
+  /**
+   * @brief 予約中のモーションの優先度の設定
+   *
+   * 予約中のモーションの優先度を設定する。
+   *
+   * @param[in]   priority     優先度
+   */
+  public setReservePriority(priority: number) {
+    this._reservePriority = priority;
+  }
+
+  /**
+   * @brief 優先度を設定してモーションの開始
+   *
+   * 優先度を設定してモーションを開始する。
+   *
+   * @param[in]   motion          モーション
+   * @param[in]   autoDelete      再生が終了したモーションのインスタンスを削除するならtrue
+   * @param[in]   priority        優先度
+   * @return                      開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するIsFinished()の引数で使用する。開始できない時は「-1」
+   */
+  public startMotionPriority(
+    motion: ACubismMotion,
+    autoDelete: boolean,
+    priority: number
+  ): CubismMotionQueueEntryHandle {
+    if (priority == this.getReservePriority()) {
+      this.setReservePriority(0);
+    }
+    this._currentPriority = priority;
+
+    return this.startMotion(motion, autoDelete, this._userTimeSeconds);
+  }
+
+  /**
+   * @brief モーションの更新
+   *
+   * モーションを更新して、モデルにパラメータ値を反映する。
+   *
+   * @param[in]   model   対象のモデル
+   * @param[in]   deltaTimeSeconds    デルタ時間[秒]
+   * @retval  true    更新されている
+   * @retval  false   更新されていない
+   */
+  public updateMotion(model: CubismModel, deltaTimeSeconds: number): boolean {
+    this._userTimeSeconds += deltaTimeSeconds;
+    let updated = false;
+    const motions = this.getCubismMotionQueueEntries();
+
+    let expressionWeight = 0.0;
+    let expressionIndex = 0;
+
+    // ------- 処理を行う --------
+    // 既にモーションがあれば終了フラグを立てる
+    for (
+      let ite: iterator<CubismMotionQueueEntry> = this._motions.begin();
+      ite.notEqual(this._motions.end());
+
+    ) {
+      const motionQueueEntry = ite.ptr();
+
+      if (motionQueueEntry == null) {
+        ite = motions.erase(ite); //削除
+        continue;
+      }
+
+      const expressionMotion = <CubismExpressionMotion>(
+        motionQueueEntry.getCubismMotion()
+      );
+
+      if (expressionMotion == null) {
+        csmDelete(motionQueueEntry);
+        ite = motions.erase(ite); //削除
+        continue;
+      }
+
+      const expressionParameters = expressionMotion.getExpressionParameters();
+
+      if (motionQueueEntry.isAvailable()) {
+        // 再生中のExpressionが参照しているパラメータをすべてリストアップ
+        for (let i = 0; i < expressionParameters.getSize(); ++i) {
+          if (expressionParameters.at(i).parameterId == null) {
+            continue;
+          }
+
+          let index = -1;
+          // リストにパラメータIDが存在するか検索
+          for (let j = 0; j < this._expressionParameterValues.getSize(); ++j) {
+            if (
+              this._expressionParameterValues.at(j).parameterId !=
+              expressionParameters.at(i).parameterId
+            ) {
+              continue;
+            }
+
+            index = j;
+            break;
+          }
+
+          if (index >= 0) {
+            continue;
+          }
+
+          // パラメータがリストに存在しないなら新規追加
+          const item: ExpressionParameterValue = new ExpressionParameterValue();
+          item.parameterId = expressionParameters.at(i).parameterId;
+          item.additiveValue = CubismExpressionMotion.DefaultAdditiveValue;
+          item.multiplyValue = CubismExpressionMotion.DefaultMultiplyValue;
+          item.overwriteValue = model.getParameterValueById(item.parameterId);
+          this._expressionParameterValues.pushBack(item);
+        }
+      }
+
+      // ------ 値を計算する ------
+      expressionMotion.calculateExpressionParameters(
+        model,
+        this._userTimeSeconds,
+        motionQueueEntry,
+        this._expressionParameterValues,
+        expressionIndex
+      );
+
+      expressionWeight +=
+        expressionMotion.getFadeInTime() == 0.0
+          ? 1.0
+          : CubismMath.getEasingSine(
+              (this._userTimeSeconds - motionQueueEntry.getFadeInStartTime()) /
+                expressionMotion.getFadeInTime()
+            );
+
+      updated = true;
+
+      if (motionQueueEntry.isTriggeredFadeOut()) {
+        // フェードアウト開始
+        motionQueueEntry.startFadeOut(
+          motionQueueEntry.getFadeOutSeconds(),
+          this._userTimeSeconds
+        );
+      }
+
+      ite.preIncrement();
+      ++expressionIndex;
+    }
+
+    // ----- 最新のExpressionのフェードが完了していればそれ以前を削除する ------
+    if (motions.getSize() > 1) {
+      const expressionMotion = <CubismExpressionMotion>(
+        motions.at(motions.getSize() - 1).getCubismMotion()
+      );
+      if (expressionMotion.getFadeWeight() >= 1.0) {
+        // 配列の最後の要素は削除しない
+        for (let i = motions.getSize() - 2; i >= 0; --i) {
+          const motionQueueEntry = motions.at(i);
+          csmDelete(motionQueueEntry);
+          motions.remove(i);
+        }
+      }
+    }
+
+    if (expressionWeight > 1.0) {
+      expressionWeight = 1.0;
+    }
+
+    // モデルに各値を適用
+    for (let i = 0; i < this._expressionParameterValues.getSize(); ++i) {
+      const expressionParameterValue = this._expressionParameterValues.at(i);
+      model.setParameterValueById(
+        expressionParameterValue.parameterId,
+        (expressionParameterValue.overwriteValue +
+          expressionParameterValue.additiveValue) *
+          expressionParameterValue.multiplyValue,
+        expressionWeight
+      );
+
+      expressionParameterValue.additiveValue =
+        CubismExpressionMotion.DefaultAdditiveValue;
+      expressionParameterValue.multiplyValue =
+        CubismExpressionMotion.DefaultMultiplyValue;
+    }
+
+    return updated;
+  }
+
+  private _expressionParameterValues: csmVector<ExpressionParameterValue>; ///< モデルに適用する各パラメータの値
+  private _currentPriority: number; ///< 現在再生中のモーションの優先度
+  private _reservePriority: number; ///< 再生予定のモーションの優先度。再生中は0になる。モーションファイルを別スレッドで読み込むときの機能。
+  private _startExpressionTime: number; ///< 表情の再生開始時刻
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismexpressionmotionmanager';
+import { CubismMath } from '../math/cubismmath';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismExpressionMotionManager = $.CubismExpressionMotionManager;
+  export type CubismExpressionMotionManager = $.CubismExpressionMotionManager;
+}

--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -14,7 +14,7 @@ import { csmVector } from '../type/csmvector';
 import {
   CSM_ASSERT,
   CubismLogDebug,
-  CubismLogWarning,
+  CubismLogWarning
 } from '../utils/cubismdebug';
 import { ACubismMotion, FinishedMotionCallback } from './acubismmotion';
 import {
@@ -24,7 +24,7 @@ import {
   CubismMotionEvent,
   CubismMotionPoint,
   CubismMotionSegment,
-  CubismMotionSegmentType,
+  CubismMotionSegmentType
 } from './cubismmotioninternal';
 import { CubismMotionJson, EvaluationOptionFlag } from './cubismmotionjson';
 import { CubismMotionQueueEntry } from './cubismmotionqueueentry';
@@ -212,7 +212,7 @@ function evaluateCurve(
     // Get first point of next segment.
     pointPosition =
       motionData.segments.at(i).basePointIndex +
-      (motionData.segments.at(i).segmentType ==
+      ((motionData.segments.at(i).segmentType as CubismMotionSegmentType) ==
       CubismMotionSegmentType.CubismMotionSegmentType_Bezier
         ? 3
         : 1);

--- a/src/motion/cubismmotioninternal.ts
+++ b/src/motion/cubismmotioninternal.ts
@@ -17,7 +17,7 @@ import { csmVector } from '../type/csmvector';
 export enum CubismMotionCurveTarget {
   CubismMotionCurveTarget_Model, // モデルに対して
   CubismMotionCurveTarget_Parameter, // パラメータに対して
-  CubismMotionCurveTarget_PartOpacity, // パーツの不透明度に対して
+  CubismMotionCurveTarget_PartOpacity // パーツの不透明度に対して
 }
 
 /**
@@ -29,7 +29,7 @@ export enum CubismMotionSegmentType {
   CubismMotionSegmentType_Linear = 0, // リニア
   CubismMotionSegmentType_Bezier = 1, // ベジェ曲線
   CubismMotionSegmentType_Stepped = 2, // ステップ
-  CubismMotionSegmentType_InverseStepped = 3, // インバースステップ
+  CubismMotionSegmentType_InverseStepped = 3 // インバースステップ
 }
 
 /**

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -76,7 +76,7 @@ export class CubismMotionJson {
       .toBoolean();
   }
 
-  public getEvaluationOptionFlag(flagType: number): boolean {
+  public getEvaluationOptionFlag(flagType: EvaluationOptionFlag): boolean {
     if (
       EvaluationOptionFlag.EvaluationOptionFlag_AreBeziersRistricted == flagType
     ) {
@@ -371,7 +371,7 @@ export class CubismMotionJson {
  * @brief ベジェカーブの解釈方法のフラグタイプ
  */
 export enum EvaluationOptionFlag {
-  EvaluationOptionFlag_AreBeziersRistricted = 0, ///< ベジェハンドルの規制状態
+  EvaluationOptionFlag_AreBeziersRistricted = 0 ///< ベジェハンドルの規制状態
 }
 
 // Namespace definition for compatibility.

--- a/src/motion/cubismmotionmanager.ts
+++ b/src/motion/cubismmotionmanager.ts
@@ -9,7 +9,7 @@ import { CubismModel } from '../model/cubismmodel';
 import { ACubismMotion } from './acubismmotion';
 import {
   CubismMotionQueueEntryHandle,
-  CubismMotionQueueManager,
+  CubismMotionQueueManager
 } from './cubismmotionqueuemanager';
 
 /**

--- a/src/motion/cubismmotionqueueentry.ts
+++ b/src/motion/cubismmotionqueueentry.ts
@@ -226,6 +226,15 @@ export class CubismMotionQueueEntry {
     return this._fadeOutSeconds;
   }
 
+  /**
+   * モーションの取得
+   *
+   * @return モーション
+   */
+  public getCubismMotion(): ACubismMotion {
+    return this._motion;
+  }
+
   _autoDelete: boolean; // 自動削除
   _motion: ACubismMotion; // モーション
 

--- a/src/motion/cubismmotionqueuemanager.ts
+++ b/src/motion/cubismmotionqueuemanager.ts
@@ -184,12 +184,24 @@ export class CubismMotionQueueManager {
   }
 
   /**
-       * 指定したCubismMotionQueueEntryの取得
+   * @brief CubismMotionQueueEntryの配列の取得
+   *
+   * CubismMotionQueueEntryの配列を取得する。
+   *
+   * @return  CubismMotionQueueEntryの配列へのポインタ
+   * @retval  NULL   見つからなかった
+   */
+  public getCubismMotionQueueEntries(): csmVector<CubismMotionQueueEntry> {
+    return this._motions;
+  }
 
-        * @param   motionQueueEntryNumber  モーションの識別番号
-        * @return  指定したCubismMotionQueueEntry
-        * @return  null   見つからなかった
-        */
+  /**
+   * 指定したCubismMotionQueueEntryの取得
+
+   * @param   motionQueueEntryNumber  モーションの識別番号
+   * @return  指定したCubismMotionQueueEntry
+   * @return  null   見つからなかった
+   */
   public getCubismMotionQueueEntry(
     motionQueueEntryNumber: any
   ): CubismMotionQueueEntry {

--- a/src/physics/cubismphysics.ts
+++ b/src/physics/cubismphysics.ts
@@ -17,7 +17,7 @@ import {
   CubismPhysicsRig,
   CubismPhysicsSource,
   CubismPhysicsSubRig,
-  CubismPhysicsTargetType,
+  CubismPhysicsTargetType
 } from './cubismphysicsinternal';
 import { CubismPhysicsJson } from './cubismphysicsjson';
 

--- a/src/physics/cubismphysicsinternal.ts
+++ b/src/physics/cubismphysicsinternal.ts
@@ -13,7 +13,7 @@ import { csmVector } from '../type/csmvector';
  * 物理演算の適用先の種類
  */
 export enum CubismPhysicsTargetType {
-  CubismPhysicsTargetType_Parameter, // パラメータに対して適用
+  CubismPhysicsTargetType_Parameter // パラメータに対して適用
 }
 
 /**
@@ -22,7 +22,7 @@ export enum CubismPhysicsTargetType {
 export enum CubismPhysicsSource {
   CubismPhysicsSource_X, // X軸の位置から
   CubismPhysicsSource_Y, // Y軸の位置から
-  CubismPhysicsSource_Angle, // 角度から
+  CubismPhysicsSource_Angle // 角度から
 }
 
 /**

--- a/src/rendering/cubismclippingmanager.ts
+++ b/src/rendering/cubismclippingmanager.ts
@@ -1,0 +1,706 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { Constant } from '../live2dcubismframework';
+import { csmVector } from '../type/csmvector';
+import { csmRect } from '../type/csmrectf';
+import { CubismMatrix44 } from '../math/cubismmatrix44';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismClippingContext, CubismTextureColor } from './cubismrenderer';
+import { CubismLogError, CubismLogWarning } from '../utils/cubismdebug';
+
+const ColorChannelCount = 4; // 実験時に1チャンネルの場合は1、RGBだけの場合は3、アルファも含める場合は4
+const ClippingMaskMaxCountOnDefault = 36; // 通常のフレームバッファ一枚あたりのマスク最大数
+const ClippingMaskMaxCountOnMultiRenderTexture = 32; // フレームバッファが2枚以上ある場合のフレームバッファ一枚あたりのマスク最大数
+
+export type ClippingContextConstructor<
+  T_ClippingContext extends CubismClippingContext
+> = new (
+  manager: CubismClippingManager<T_ClippingContext>,
+  drawableMasks: Int32Array,
+  drawableMaskCounts: number
+) => T_ClippingContext;
+
+export interface ICubismClippingManager {
+  getClippingMaskBufferSize(): number;
+}
+
+export abstract class CubismClippingManager<
+  T_ClippingContext extends CubismClippingContext
+> implements ICubismClippingManager
+{
+  /**
+   * コンストラクタ
+   */
+  public constructor(
+    clippingContextFactory: ClippingContextConstructor<T_ClippingContext>
+  ) {
+    this._renderTextureCount = 0;
+    this._clippingMaskBufferSize = 256;
+    this._clippingContextListForMask = new csmVector<T_ClippingContext>();
+    this._clippingContextListForDraw = new csmVector<T_ClippingContext>();
+    this._channelColors = new csmVector<CubismTextureColor>();
+    this._tmpBoundsOnModel = new csmRect();
+    this._tmpMatrix = new CubismMatrix44();
+    this._tmpMatrixForMask = new CubismMatrix44();
+    this._tmpMatrixForDraw = new CubismMatrix44();
+
+    this._clippingContexttConstructor = clippingContextFactory;
+
+    let tmp: CubismTextureColor = new CubismTextureColor();
+    tmp.R = 1.0;
+    tmp.G = 0.0;
+    tmp.B = 0.0;
+    tmp.A = 0.0;
+    this._channelColors.pushBack(tmp);
+
+    tmp = new CubismTextureColor();
+    tmp.R = 0.0;
+    tmp.G = 1.0;
+    tmp.B = 0.0;
+    tmp.A = 0.0;
+    this._channelColors.pushBack(tmp);
+
+    tmp = new CubismTextureColor();
+    tmp.R = 0.0;
+    tmp.G = 0.0;
+    tmp.B = 1.0;
+    tmp.A = 0.0;
+    this._channelColors.pushBack(tmp);
+
+    tmp = new CubismTextureColor();
+    tmp.R = 0.0;
+    tmp.G = 0.0;
+    tmp.B = 0.0;
+    tmp.A = 1.0;
+    this._channelColors.pushBack(tmp);
+  }
+
+  /**
+   * デストラクタ相当の処理
+   */
+  public release(): void {
+    for (let i = 0; i < this._clippingContextListForMask.getSize(); i++) {
+      if (this._clippingContextListForMask.at(i)) {
+        this._clippingContextListForMask.at(i).release();
+        this._clippingContextListForMask.set(i, void 0);
+      }
+      this._clippingContextListForMask.set(i, null);
+    }
+    this._clippingContextListForMask = null;
+
+    // _clippingContextListForDrawは_clippingContextListForMaskにあるインスタンスを指している。上記の処理により要素ごとのDELETEは不要。
+    for (let i = 0; i < this._clippingContextListForDraw.getSize(); i++) {
+      this._clippingContextListForDraw.set(i, null);
+    }
+    this._clippingContextListForDraw = null;
+
+    for (let i = 0; i < this._channelColors.getSize(); i++) {
+      this._channelColors.set(i, null);
+    }
+
+    this._channelColors = null;
+
+    if (this._clearedFrameBufferFlags != null) {
+      this._clearedFrameBufferFlags.clear();
+    }
+    this._clearedFrameBufferFlags = null;
+  }
+
+  /**
+   * マネージャの初期化処理
+   * クリッピングマスクを使う描画オブジェクトの登録を行う
+   * @param model モデルのインスタンス
+   * @param renderTextureCount バッファの生成数
+   */
+  public initialize(model: CubismModel, renderTextureCount: number): void {
+    // レンダーテクスチャの合計枚数の設定
+    // 1以上の整数でない場合はそれぞれ警告を出す
+    if (renderTextureCount % 1 != 0) {
+      CubismLogWarning(
+        'The number of render textures must be specified as an integer. The decimal point is rounded down and corrected to an integer.'
+      );
+      // 小数点以下を除去
+      renderTextureCount = ~~renderTextureCount;
+    }
+    if (renderTextureCount < 1) {
+      CubismLogWarning(
+        'The number of render textures must be an integer greater than or equal to 1. Set the number of render textures to 1.'
+      );
+    }
+    // 負の値が使われている場合は強制的に1枚と設定する
+    this._renderTextureCount = renderTextureCount < 1 ? 1 : renderTextureCount;
+
+    this._clearedFrameBufferFlags = new csmVector<boolean>(
+      this._renderTextureCount
+    );
+
+    // クリッピングマスクを使う描画オブジェクトをすべて登録する
+    // クリッピングマスクは、通常数個程度に限定して使うものとする
+    for (let i = 0; i < model.getDrawableCount(); i++) {
+      if (model.getDrawableMaskCounts()[i] <= 0) {
+        // クリッピングマスクが使用されていないアートメッシュ（多くの場合使用しない）
+        this._clippingContextListForDraw.pushBack(null);
+        continue;
+      }
+
+      // 既にあるClipContextと同じかチェックする
+      let clippingContext: T_ClippingContext = this.findSameClip(
+        model.getDrawableMasks()[i],
+        model.getDrawableMaskCounts()[i]
+      );
+      if (clippingContext == null) {
+        // 同一のマスクが存在していない場合は生成する
+
+        clippingContext = new this._clippingContexttConstructor(
+          this,
+          model.getDrawableMasks()[i],
+          model.getDrawableMaskCounts()[i]
+        );
+        this._clippingContextListForMask.pushBack(clippingContext);
+      }
+
+      clippingContext.addClippedDrawable(i);
+
+      this._clippingContextListForDraw.pushBack(clippingContext);
+    }
+  }
+
+  /**
+   * 既にマスクを作っているかを確認
+   * 作っている様であれば該当するクリッピングマスクのインスタンスを返す
+   * 作っていなければNULLを返す
+   * @param drawableMasks 描画オブジェクトをマスクする描画オブジェクトのリスト
+   * @param drawableMaskCounts 描画オブジェクトをマスクする描画オブジェクトの数
+   * @return 該当するクリッピングマスクが存在すればインスタンスを返し、なければNULLを返す
+   */
+  public findSameClip(
+    drawableMasks: Int32Array,
+    drawableMaskCounts: number
+  ): T_ClippingContext {
+    // 作成済みClippingContextと一致するか確認
+    for (let i = 0; i < this._clippingContextListForMask.getSize(); i++) {
+      const clippingContext: T_ClippingContext =
+        this._clippingContextListForMask.at(i);
+      const count: number = clippingContext._clippingIdCount;
+
+      // 個数が違う場合は別物
+      if (count != drawableMaskCounts) {
+        continue;
+      }
+
+      let sameCount = 0;
+
+      // 同じIDを持つか確認。配列の数が同じなので、一致した個数が同じなら同じ物を持つとする
+      for (let j = 0; j < count; j++) {
+        const clipId: number = clippingContext._clippingIdList[j];
+
+        for (let k = 0; k < count; k++) {
+          if (drawableMasks[k] == clipId) {
+            sameCount++;
+            break;
+          }
+        }
+      }
+
+      if (sameCount == count) {
+        return clippingContext;
+      }
+    }
+
+    return null; // 見つからなかった
+  }
+
+  /**
+   * 高精細マスク処理用の行列を計算する
+   * @param model モデルのインスタンス
+   * @param isRightHanded 処理が右手系であるか
+   */
+  public setupMatrixForHighPrecision(
+    model: CubismModel,
+    isRightHanded: boolean
+  ): void {
+    // 全てのクリッピングを用意する
+    // 同じクリップ（複数の場合はまとめて一つのクリップ）を使う場合は1度だけ設定する
+    let usingClipCount = 0;
+    for (
+      let clipIndex = 0;
+      clipIndex < this._clippingContextListForMask.getSize();
+      clipIndex++
+    ) {
+      // １つのクリッピングマスクに関して
+      const cc: T_ClippingContext =
+        this._clippingContextListForMask.at(clipIndex);
+
+      // このクリップを利用する描画オブジェクト群全体を囲む矩形を計算
+      this.calcClippedDrawTotalBounds(model, cc);
+
+      if (cc._isUsing) {
+        usingClipCount++; // 使用中としてカウント
+      }
+    }
+
+    // マスク行列作成処理
+    if (usingClipCount > 0) {
+      this.setupLayoutBounds(0);
+
+      // サイズがレンダーテクスチャの枚数と合わない場合は合わせる
+      if (this._clearedFrameBufferFlags.getSize() != this._renderTextureCount) {
+        this._clearedFrameBufferFlags.clear();
+        for (let i = 0; i < this._renderTextureCount; i++) {
+          this._clearedFrameBufferFlags.pushBack(false);
+        }
+      } else {
+        // マスクのクリアフラグを毎フレーム開始時に初期化
+        for (let i = 0; i < this._renderTextureCount; i++) {
+          this._clearedFrameBufferFlags.set(i, false);
+        }
+      }
+
+      // 実際にマスクを生成する
+      // 全てのマスクをどの様にレイアウトして描くかを決定し、ClipContext , ClippedDrawContext に記憶する
+      for (
+        let clipIndex = 0;
+        clipIndex < this._clippingContextListForMask.getSize();
+        clipIndex++
+      ) {
+        // --- 実際に１つのマスクを描く ---
+        const clipContext: T_ClippingContext =
+          this._clippingContextListForMask.at(clipIndex);
+        const allClippedDrawRect: csmRect = clipContext._allClippedDrawRect; //このマスクを使う、全ての描画オブジェクトの論理座標上の囲み矩形
+        const layoutBoundsOnTex01 = clipContext._layoutBounds; //この中にマスクを収める
+        const MARGIN = 0.05;
+        let scaleX = 0.0;
+        let scaleY = 0.0;
+        const ppu: number = model.getPixelsPerUnit();
+        const maskPixelSize: number = clipContext
+          .getClippingManager()
+          .getClippingMaskBufferSize();
+        const physicalMaskWidth: number =
+          layoutBoundsOnTex01.width * maskPixelSize;
+        const physicalMaskHeight: number =
+          layoutBoundsOnTex01.height * maskPixelSize;
+
+        this._tmpBoundsOnModel.setRect(allClippedDrawRect);
+        if (this._tmpBoundsOnModel.width * ppu > physicalMaskWidth) {
+          this._tmpBoundsOnModel.expand(allClippedDrawRect.width * MARGIN, 0.0);
+          scaleX = layoutBoundsOnTex01.width / this._tmpBoundsOnModel.width;
+        } else {
+          scaleX = ppu / physicalMaskWidth;
+        }
+
+        if (this._tmpBoundsOnModel.height * ppu > physicalMaskHeight) {
+          this._tmpBoundsOnModel.expand(
+            0.0,
+            allClippedDrawRect.height * MARGIN
+          );
+          scaleY = layoutBoundsOnTex01.height / this._tmpBoundsOnModel.height;
+        } else {
+          scaleY = ppu / physicalMaskHeight;
+        }
+
+        // マスク生成時に使う行列を求める
+        this.createMatrixForMask(
+          isRightHanded,
+          layoutBoundsOnTex01,
+          scaleX,
+          scaleY
+        );
+
+        clipContext._matrixForMask.setMatrix(this._tmpMatrixForMask.getArray());
+        clipContext._matrixForDraw.setMatrix(this._tmpMatrixForDraw.getArray());
+      }
+    }
+  }
+
+  /**
+   * マスク作成・描画用の行列を作成する。
+   * @param isRightHanded 座標を右手系として扱うかを指定
+   * @param layoutBoundsOnTex01 マスクを収める領域
+   * @param scaleX 描画オブジェクトの伸縮率
+   * @param scaleY 描画オブジェクトの伸縮率
+   */
+  public createMatrixForMask(
+    isRightHanded: boolean,
+    layoutBoundsOnTex01: csmRect,
+    scaleX: number,
+    scaleY: number
+  ): void {
+    this._tmpMatrix.loadIdentity();
+    {
+      // Layout0..1 を -1..1に変換
+      this._tmpMatrix.translateRelative(-1.0, -1.0);
+      this._tmpMatrix.scaleRelative(2.0, 2.0);
+    }
+    {
+      // view to Layout0..1
+      this._tmpMatrix.translateRelative(
+        layoutBoundsOnTex01.x,
+        layoutBoundsOnTex01.y
+      ); //new = [translate]
+      this._tmpMatrix.scaleRelative(scaleX, scaleY); //new = [translate][scale]
+      this._tmpMatrix.translateRelative(
+        -this._tmpBoundsOnModel.x,
+        -this._tmpBoundsOnModel.y
+      ); //new = [translate][scale][translate]
+    }
+    // tmpMatrixForMask が計算結果
+    this._tmpMatrixForMask.setMatrix(this._tmpMatrix.getArray());
+
+    this._tmpMatrix.loadIdentity();
+    {
+      this._tmpMatrix.translateRelative(
+        layoutBoundsOnTex01.x,
+        layoutBoundsOnTex01.y * (isRightHanded ? -1.0 : 1.0)
+      ); //new = [translate]
+      this._tmpMatrix.scaleRelative(
+        scaleX,
+        scaleY * (isRightHanded ? -1.0 : 1.0)
+      ); //new = [translate][scale]
+      this._tmpMatrix.translateRelative(
+        -this._tmpBoundsOnModel.x,
+        -this._tmpBoundsOnModel.y
+      ); //new = [translate][scale][translate]
+    }
+
+    this._tmpMatrixForDraw.setMatrix(this._tmpMatrix.getArray());
+  }
+
+  /**
+   * クリッピングコンテキストを配置するレイアウト
+   * 指定された数のレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする
+   * マスクグループの数が4以下ならRGBA各チャンネルに一つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する。
+   *
+   * @param usingClipCount 配置するクリッピングコンテキストの数
+   */
+  public setupLayoutBounds(usingClipCount: number): void {
+    const useClippingMaskMaxCount =
+      this._renderTextureCount <= 1
+        ? ClippingMaskMaxCountOnDefault
+        : ClippingMaskMaxCountOnMultiRenderTexture * this._renderTextureCount;
+
+    if (usingClipCount <= 0 || usingClipCount > useClippingMaskMaxCount) {
+      if (usingClipCount > useClippingMaskMaxCount) {
+        // マスクの制限数の警告を出す
+        CubismLogError(
+          'not supported mask count : {0}\n[Details] render texture count : {1}, mask count : {2}',
+          usingClipCount - useClippingMaskMaxCount,
+          this._renderTextureCount,
+          usingClipCount
+        );
+      }
+      // この場合は一つのマスクターゲットを毎回クリアして使用する
+      for (
+        let index = 0;
+        index < this._clippingContextListForMask.getSize();
+        index++
+      ) {
+        const clipContext: T_ClippingContext =
+          this._clippingContextListForMask.at(index);
+        clipContext._layoutChannelNo = 0; // どうせ毎回消すので固定
+        clipContext._layoutBounds.x = 0.0;
+        clipContext._layoutBounds.y = 0.0;
+        clipContext._layoutBounds.width = 1.0;
+        clipContext._layoutBounds.height = 1.0;
+        clipContext._bufferIndex = 0;
+      }
+      return;
+    }
+
+    // レンダーテクスチャが1枚なら9分割する（最大36枚）
+    const layoutCountMaxValue = this._renderTextureCount <= 1 ? 9 : 8;
+
+    // 指定された数のレンダーテクスチャを極力いっぱいに使ってマスクをレイアウトする（デフォルトなら1）
+    // マスクグループの数が4以下ならRGBA各チャンネルに1つずつマスクを配置し、5以上6以下ならRGBAを2,2,1,1と配置する
+    let countPerSheetDiv: number = usingClipCount / this._renderTextureCount; // レンダーテクスチャ1枚あたり何枚割り当てるか
+    let countPerSheetMod: number = usingClipCount % this._renderTextureCount; // この番号のレンダーテクスチャまでに一つずつ配分する
+
+    // 小数点は切り捨てる
+    countPerSheetDiv = ~~countPerSheetDiv;
+    countPerSheetMod = ~~countPerSheetMod;
+
+    // RGBAを順番に使っていく
+    let div: number = countPerSheetDiv / ColorChannelCount; // 1チャンネルに配置する基本のマスク
+    let mod: number = countPerSheetDiv % ColorChannelCount; // 余り、この番号のチャンネルまでに一つずつ配分する
+
+    // 小数点は切り捨てる
+    div = ~~div;
+    mod = ~~mod;
+
+    // RGBAそれぞれのチャンネルを用意していく（0:R, 1:G, 2:B, 3:A）
+    let curClipIndex = 0; // 順番に設定していく
+
+    for (
+      let renderTextureNo = 0;
+      renderTextureNo < this._renderTextureCount;
+      renderTextureNo++
+    ) {
+      for (let channelNo = 0; channelNo < ColorChannelCount; channelNo++) {
+        // このチャンネルにレイアウトする数
+        let layoutCount: number = div + (channelNo < mod ? 1 : 0);
+
+        // このレンダーテクスチャにまだ割り当てられていなければ追加する
+        const checkChannelNo = mod + 1 >= ColorChannelCount ? 0 : mod + 1;
+        if (layoutCount < layoutCountMaxValue && channelNo == checkChannelNo) {
+          layoutCount += renderTextureNo < countPerSheetMod ? 1 : 0;
+        }
+
+        // 分割方法を決定する
+        if (layoutCount == 0) {
+          // 何もしない
+        } else if (layoutCount == 1) {
+          // 全てをそのまま使う
+          const clipContext: T_ClippingContext =
+            this._clippingContextListForMask.at(curClipIndex++);
+          clipContext._layoutChannelNo = channelNo;
+          clipContext._layoutBounds.x = 0.0;
+          clipContext._layoutBounds.y = 0.0;
+          clipContext._layoutBounds.width = 1.0;
+          clipContext._layoutBounds.height = 1.0;
+          clipContext._bufferIndex = renderTextureNo;
+        } else if (layoutCount == 2) {
+          for (let i = 0; i < layoutCount; i++) {
+            let xpos: number = i % 2;
+
+            // 小数点は切り捨てる
+            xpos = ~~xpos;
+
+            const cc: T_ClippingContext = this._clippingContextListForMask.at(
+              curClipIndex++
+            );
+            cc._layoutChannelNo = channelNo;
+
+            // UVを2つに分解して使う
+            cc._layoutBounds.x = xpos * 0.5;
+            cc._layoutBounds.y = 0.0;
+            cc._layoutBounds.width = 0.5;
+            cc._layoutBounds.height = 1.0;
+            cc._bufferIndex = renderTextureNo;
+          }
+        } else if (layoutCount <= 4) {
+          // 4分割して使う
+          for (let i = 0; i < layoutCount; i++) {
+            let xpos: number = i % 2;
+            let ypos: number = i / 2;
+
+            // 小数点は切り捨てる
+            xpos = ~~xpos;
+            ypos = ~~ypos;
+
+            const cc = this._clippingContextListForMask.at(curClipIndex++);
+            cc._layoutChannelNo = channelNo;
+
+            cc._layoutBounds.x = xpos * 0.5;
+            cc._layoutBounds.y = ypos * 0.5;
+            cc._layoutBounds.width = 0.5;
+            cc._layoutBounds.height = 0.5;
+            cc._bufferIndex = renderTextureNo;
+          }
+        } else if (layoutCount <= layoutCountMaxValue) {
+          // 9分割して使う
+          for (let i = 0; i < layoutCount; i++) {
+            let xpos = i % 3;
+            let ypos = i / 3;
+
+            // 小数点は切り捨てる
+            xpos = ~~xpos;
+            ypos = ~~ypos;
+
+            const cc: T_ClippingContext = this._clippingContextListForMask.at(
+              curClipIndex++
+            );
+            cc._layoutChannelNo = channelNo;
+
+            cc._layoutBounds.x = xpos / 3.0;
+            cc._layoutBounds.y = ypos / 3.0;
+            cc._layoutBounds.width = 1.0 / 3.0;
+            cc._layoutBounds.height = 1.0 / 3.0;
+            cc._bufferIndex = renderTextureNo;
+          }
+        } else {
+          // マスクの制限枚数を超えた場合の処理
+          CubismLogError(
+            'not supported mask count : {0}\n[Details] render texture count : {1}, mask count : {2}',
+            usingClipCount - useClippingMaskMaxCount,
+            this._renderTextureCount,
+            usingClipCount
+          );
+
+          // SetupShaderProgramでオーバーアクセスが発生するので仮で数値を入れる
+          // もちろん描画結果は正しいものではなくなる
+          for (let index = 0; index < layoutCount; index++) {
+            const cc: T_ClippingContext = this._clippingContextListForMask.at(
+              curClipIndex++
+            );
+
+            cc._layoutChannelNo = 0;
+
+            cc._layoutBounds.x = 0.0;
+            cc._layoutBounds.y = 0.0;
+            cc._layoutBounds.width = 1.0;
+            cc._layoutBounds.height = 1.0;
+            cc._bufferIndex = 0;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * マスクされる描画オブジェクト群全体を囲む矩形（モデル座標系）を計算する
+   * @param model モデルのインスタンス
+   * @param clippingContext クリッピングマスクのコンテキスト
+   */
+  public calcClippedDrawTotalBounds(
+    model: CubismModel,
+    clippingContext: T_ClippingContext
+  ): void {
+    // 被クリッピングマスク（マスクされる描画オブジェクト）の全体の矩形
+    let clippedDrawTotalMinX: number = Number.MAX_VALUE;
+    let clippedDrawTotalMinY: number = Number.MAX_VALUE;
+    let clippedDrawTotalMaxX: number = Number.MIN_VALUE;
+    let clippedDrawTotalMaxY: number = Number.MIN_VALUE;
+
+    // このマスクが実際に必要か判定する
+    // このクリッピングを利用する「描画オブジェクト」がひとつでも使用可能であればマスクを生成する必要がある
+    const clippedDrawCount: number =
+      clippingContext._clippedDrawableIndexList.length;
+
+    for (
+      let clippedDrawableIndex = 0;
+      clippedDrawableIndex < clippedDrawCount;
+      clippedDrawableIndex++
+    ) {
+      // マスクを使用する描画オブジェクトの描画される矩形を求める
+      const drawableIndex: number =
+        clippingContext._clippedDrawableIndexList[clippedDrawableIndex];
+
+      const drawableVertexCount: number =
+        model.getDrawableVertexCount(drawableIndex);
+      const drawableVertexes: Float32Array =
+        model.getDrawableVertices(drawableIndex);
+
+      let minX: number = Number.MAX_VALUE;
+      let minY: number = Number.MAX_VALUE;
+      let maxX: number = -Number.MAX_VALUE;
+      let maxY: number = -Number.MAX_VALUE;
+
+      const loop: number = drawableVertexCount * Constant.vertexStep;
+      for (
+        let pi: number = Constant.vertexOffset;
+        pi < loop;
+        pi += Constant.vertexStep
+      ) {
+        const x: number = drawableVertexes[pi];
+        const y: number = drawableVertexes[pi + 1];
+
+        if (x < minX) {
+          minX = x;
+        }
+        if (x > maxX) {
+          maxX = x;
+        }
+        if (y < minY) {
+          minY = y;
+        }
+        if (y > maxY) {
+          maxY = y;
+        }
+      }
+
+      // 有効な点が一つも取れなかったのでスキップ
+      if (minX == Number.MAX_VALUE) {
+        continue;
+      }
+
+      // 全体の矩形に反映
+      if (minX < clippedDrawTotalMinX) {
+        clippedDrawTotalMinX = minX;
+      }
+      if (minY < clippedDrawTotalMinY) {
+        clippedDrawTotalMinY = minY;
+      }
+      if (maxX > clippedDrawTotalMaxX) {
+        clippedDrawTotalMaxX = maxX;
+      }
+      if (maxY > clippedDrawTotalMaxY) {
+        clippedDrawTotalMaxY = maxY;
+      }
+
+      if (clippedDrawTotalMinX == Number.MAX_VALUE) {
+        clippingContext._allClippedDrawRect.x = 0.0;
+        clippingContext._allClippedDrawRect.y = 0.0;
+        clippingContext._allClippedDrawRect.width = 0.0;
+        clippingContext._allClippedDrawRect.height = 0.0;
+        clippingContext._isUsing = false;
+      } else {
+        clippingContext._isUsing = true;
+        const w: number = clippedDrawTotalMaxX - clippedDrawTotalMinX;
+        const h: number = clippedDrawTotalMaxY - clippedDrawTotalMinY;
+        clippingContext._allClippedDrawRect.x = clippedDrawTotalMinX;
+        clippingContext._allClippedDrawRect.y = clippedDrawTotalMinY;
+        clippingContext._allClippedDrawRect.width = w;
+        clippingContext._allClippedDrawRect.height = h;
+      }
+    }
+  }
+
+  /**
+   * 画面描画に使用するクリッピングマスクのリストを取得する
+   * @return 画面描画に使用するクリッピングマスクのリスト
+   */
+  public getClippingContextListForDraw(): csmVector<T_ClippingContext> {
+    return this._clippingContextListForDraw;
+  }
+
+  /**
+   * クリッピングマスクバッファのサイズを取得する
+   * @return クリッピングマスクバッファのサイズ
+   */
+  public getClippingMaskBufferSize(): number {
+    return this._clippingMaskBufferSize;
+  }
+
+  /**
+   * このバッファのレンダーテクスチャの枚数を取得する
+   * @return このバッファのレンダーテクスチャの枚数
+   */
+  public getRenderTextureCount(): number {
+    return this._renderTextureCount;
+  }
+
+  /**
+   * カラーチャンネル（RGBA）のフラグを取得する
+   * @param channelNo カラーチャンネル（RGBA）の番号（0:R, 1:G, 2:B, 3:A）
+   */
+  public getChannelFlagAsColor(channelNo: number): CubismTextureColor {
+    return this._channelColors.at(channelNo);
+  }
+
+  /**
+   * クリッピングマスクバッファのサイズを設定する
+   * @param size クリッピングマスクバッファのサイズ
+   */
+  public setClippingMaskBufferSize(size: number): void {
+    this._clippingMaskBufferSize = size;
+  }
+
+  protected _clearedFrameBufferFlags: csmVector<boolean>; //マスクのクリアフラグの配列
+
+  protected _channelColors: csmVector<CubismTextureColor>;
+  protected _clippingContextListForMask: csmVector<T_ClippingContext>; // マスク用クリッピングコンテキストのリスト
+  protected _clippingContextListForDraw: csmVector<T_ClippingContext>; // 描画用クリッピングコンテキストのリスト
+  protected _clippingMaskBufferSize: number; // クリッピングマスクのバッファサイズ（初期値:256）
+  protected _renderTextureCount: number; // 生成するレンダーテクスチャの枚数
+
+  protected _tmpMatrix: CubismMatrix44; // マスク計算用の行列
+  protected _tmpMatrixForMask: CubismMatrix44; // マスク計算用の行列
+  protected _tmpMatrixForDraw: CubismMatrix44; // マスク計算用の行列
+  protected _tmpBoundsOnModel: csmRect; // マスク配置計算用の矩形
+
+  protected _clippingContexttConstructor: ClippingContextConstructor<T_ClippingContext>;
+}

--- a/src/rendering/cubismshader_webgl.ts
+++ b/src/rendering/cubismshader_webgl.ts
@@ -1,0 +1,1193 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { CubismMatrix44 } from '../math/cubismmatrix44';
+import { CubismModel } from '../model/cubismmodel';
+import { csmRect } from '../type/csmrectf';
+import { csmVector } from '../type/csmvector';
+import { CubismLogError } from '../utils/cubismdebug';
+import { CubismBlendMode, CubismTextureColor } from './cubismrenderer';
+import { CubismRenderer_WebGL } from './cubismrenderer_webgl';
+
+let s_instance: CubismShader_WebGL;
+const ShaderCount = 10; // シェーダーの数 = マスク生成用 + (通常用 + 加算 + 乗算) * (マスク無の乗算済アルファ対応版 + マスク有の乗算済アルファ対応版 + マスク有反転の乗算済アルファ対応版)
+
+/**
+ * WebGL用のシェーダープログラムを生成・破棄するクラス
+ * シングルトンなクラスであり、CubismShader_WebGL.getInstanceからアクセスする。
+ */
+export class CubismShader_WebGL {
+  /**
+   * インスタンスを取得する（シングルトン）
+   * @return インスタンス
+   */
+  public static getInstance(): CubismShader_WebGL {
+    if (s_instance == null) {
+      s_instance = new CubismShader_WebGL();
+
+      return s_instance;
+    }
+    return s_instance;
+  }
+
+  /**
+   * インスタンスを開放する（シングルトン）
+   */
+  public static deleteInstance(): void {
+    if (s_instance) {
+      s_instance.release();
+      s_instance = null;
+    }
+  }
+
+  /**
+   * privateなコンストラクタ
+   */
+  private constructor() {
+    this._shaderSets = new csmVector<CubismShaderSet>();
+  }
+
+  /**
+   * デストラクタ相当の処理
+   */
+  public release(): void {
+    this.releaseShaderProgram();
+  }
+
+  /**
+   * 描画用のシェーダプログラムの一連のセットアップを実行する
+   * @param renderer レンダラー
+   * @param model 描画対象のモデル
+   * @param index 描画対象のメッシュのインデックス
+   */
+  public setupShaderProgramForDraw(
+    renderer: CubismRenderer_WebGL,
+    model: Readonly<CubismModel>,
+    index: number
+  ): void {
+    if (!renderer.isPremultipliedAlpha()) {
+      CubismLogError('NoPremultipliedAlpha is not allowed');
+    }
+
+    if (this._shaderSets.getSize() == 0) {
+      this.generateShaders();
+    }
+
+    // Blending
+    let SRC_COLOR: number;
+    let DST_COLOR: number;
+    let SRC_ALPHA: number;
+    let DST_ALPHA: number;
+
+    // _shaderSets用のオフセット計算
+    const masked: boolean = renderer.getClippingContextBufferForDraw() != null; // この描画オブジェクトはマスク対象か
+    const invertedMask: boolean = model.getDrawableInvertedMaskBit(index);
+    const offset: number = masked ? (invertedMask ? 2 : 1) : 0;
+
+    let shaderSet: CubismShaderSet;
+    switch (model.getDrawableBlendMode(index)) {
+      case CubismBlendMode.CubismBlendMode_Normal:
+      default:
+        shaderSet = this._shaderSets.at(
+          ShaderNames.ShaderNames_NormalPremultipliedAlpha + offset
+        );
+        SRC_COLOR = this.gl.ONE;
+        DST_COLOR = this.gl.ONE_MINUS_SRC_ALPHA;
+        SRC_ALPHA = this.gl.ONE;
+        DST_ALPHA = this.gl.ONE_MINUS_SRC_ALPHA;
+        break;
+
+      case CubismBlendMode.CubismBlendMode_Additive:
+        shaderSet = this._shaderSets.at(
+          ShaderNames.ShaderNames_AddPremultipliedAlpha + offset
+        );
+        SRC_COLOR = this.gl.ONE;
+        DST_COLOR = this.gl.ONE;
+        SRC_ALPHA = this.gl.ZERO;
+        DST_ALPHA = this.gl.ONE;
+        break;
+
+      case CubismBlendMode.CubismBlendMode_Multiplicative:
+        shaderSet = this._shaderSets.at(
+          ShaderNames.ShaderNames_MultPremultipliedAlpha + offset
+        );
+        SRC_COLOR = this.gl.DST_COLOR;
+        DST_COLOR = this.gl.ONE_MINUS_SRC_ALPHA;
+        SRC_ALPHA = this.gl.ZERO;
+        DST_ALPHA = this.gl.ONE;
+        break;
+    }
+
+    this.gl.useProgram(shaderSet.shaderProgram);
+
+    // 頂点配列の設定
+    if (renderer._bufferData.vertex == null) {
+      renderer._bufferData.vertex = this.gl.createBuffer();
+    }
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, renderer._bufferData.vertex);
+
+    // 頂点配列の設定
+    const vertexArray: Float32Array = model.getDrawableVertices(index);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, vertexArray, this.gl.DYNAMIC_DRAW);
+    this.gl.enableVertexAttribArray(shaderSet.attributePositionLocation);
+    this.gl.vertexAttribPointer(
+      shaderSet.attributePositionLocation,
+      2,
+      this.gl.FLOAT,
+      false,
+      0,
+      0
+    );
+
+    // テクスチャ頂点の設定
+    if (renderer._bufferData.uv == null) {
+      renderer._bufferData.uv = this.gl.createBuffer();
+    }
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, renderer._bufferData.uv);
+    const uvArray: Float32Array = model.getDrawableVertexUvs(index);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, uvArray, this.gl.DYNAMIC_DRAW);
+    this.gl.enableVertexAttribArray(shaderSet.attributeTexCoordLocation);
+    this.gl.vertexAttribPointer(
+      shaderSet.attributeTexCoordLocation,
+      2,
+      this.gl.FLOAT,
+      false,
+      0,
+      0
+    );
+
+    if (masked) {
+      this.gl.activeTexture(this.gl.TEXTURE1);
+
+      // frameBufferに書かれたテクスチャ
+      const tex: WebGLTexture = renderer
+        .getClippingContextBufferForDraw()
+        .getClippingManager()
+        .getColorBuffer()
+        .at(renderer.getClippingContextBufferForDraw()._bufferIndex);
+      this.gl.bindTexture(this.gl.TEXTURE_2D, tex);
+      this.gl.uniform1i(shaderSet.samplerTexture1Location, 1);
+
+      // view座標をClippingContextの座標に変換するための行列を設定
+      this.gl.uniformMatrix4fv(
+        shaderSet.uniformClipMatrixLocation,
+        false,
+        renderer.getClippingContextBufferForDraw()._matrixForDraw.getArray()
+      );
+
+      // 使用するカラーチャンネルを設定
+      const channelNo: number =
+        renderer.getClippingContextBufferForDraw()._layoutChannelNo;
+      const colorChannel: CubismTextureColor = renderer
+        .getClippingContextBufferForDraw()
+        .getClippingManager()
+        .getChannelFlagAsColor(channelNo);
+      this.gl.uniform4f(
+        shaderSet.uniformChannelFlagLocation,
+        colorChannel.R,
+        colorChannel.G,
+        colorChannel.B,
+        colorChannel.A
+      );
+    }
+
+    // テクスチャ設定
+    const textureNo: number = model.getDrawableTextureIndex(index);
+    const textureId: WebGLTexture = renderer
+      .getBindedTextures()
+      .getValue(textureNo);
+    this.gl.activeTexture(this.gl.TEXTURE0);
+    this.gl.bindTexture(this.gl.TEXTURE_2D, textureId);
+    this.gl.uniform1i(shaderSet.samplerTexture0Location, 0);
+
+    //座標変換
+    const matrix4x4: CubismMatrix44 = renderer.getMvpMatrix();
+    this.gl.uniformMatrix4fv(
+      shaderSet.uniformMatrixLocation,
+      false,
+      matrix4x4.getArray()
+    );
+
+    //ベース色の取得
+    const baseColor: CubismTextureColor = renderer.getModelColorWithOpacity(
+      model.getDrawableOpacity(index)
+    );
+    const multiplyColor: CubismTextureColor = model.getMultiplyColor(index);
+    const screenColor: CubismTextureColor = model.getScreenColor(index);
+
+    this.gl.uniform4f(
+      shaderSet.uniformBaseColorLocation,
+      baseColor.R,
+      baseColor.G,
+      baseColor.B,
+      baseColor.A
+    );
+
+    this.gl.uniform4f(
+      shaderSet.uniformMultiplyColorLocation,
+      multiplyColor.R,
+      multiplyColor.G,
+      multiplyColor.B,
+      multiplyColor.A
+    );
+
+    this.gl.uniform4f(
+      shaderSet.uniformScreenColorLocation,
+      screenColor.R,
+      screenColor.G,
+      screenColor.B,
+      screenColor.A
+    );
+
+    // IBOを作成し、データを転送
+    if (renderer._bufferData.index == null) {
+      renderer._bufferData.index = this.gl.createBuffer();
+    }
+    const indexArray: Uint16Array = model.getDrawableVertexIndices(index);
+
+    this.gl.bindBuffer(
+      this.gl.ELEMENT_ARRAY_BUFFER,
+      renderer._bufferData.index
+    );
+    this.gl.bufferData(
+      this.gl.ELEMENT_ARRAY_BUFFER,
+      indexArray,
+      this.gl.DYNAMIC_DRAW
+    );
+
+    this.gl.blendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
+  }
+
+  /**
+   * マスク用のシェーダプログラムの一連のセットアップを実行する
+   * @param renderer レンダラー
+   * @param model 描画対象のモデル
+   * @param index 描画対象のメッシュのインデックス
+   */
+  public setupShaderProgramForMask(
+    renderer: CubismRenderer_WebGL,
+    model: Readonly<CubismModel>,
+    index: number
+  ): void {
+    if (!renderer.isPremultipliedAlpha()) {
+      CubismLogError('NoPremultipliedAlpha is not allowed');
+    }
+
+    if (this._shaderSets.getSize() == 0) {
+      this.generateShaders();
+    }
+
+    // Blending
+    let SRC_COLOR: number;
+    let DST_COLOR: number;
+    let SRC_ALPHA: number;
+    let DST_ALPHA: number;
+
+    const shaderSet: CubismShaderSet = this._shaderSets.at(
+      ShaderNames.ShaderNames_SetupMask
+    );
+    this.gl.useProgram(shaderSet.shaderProgram);
+
+    // 頂点配列の設定
+    if (renderer._bufferData.vertex == null) {
+      renderer._bufferData.vertex = this.gl.createBuffer();
+    }
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, renderer._bufferData.vertex);
+    const vertexArray: Float32Array = model.getDrawableVertices(index);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, vertexArray, this.gl.DYNAMIC_DRAW);
+    this.gl.enableVertexAttribArray(shaderSet.attributePositionLocation);
+    this.gl.vertexAttribPointer(
+      shaderSet.attributePositionLocation,
+      2,
+      this.gl.FLOAT,
+      false,
+      0,
+      0
+    );
+
+    //テクスチャ設定
+    if (renderer._bufferData.uv == null) {
+      renderer._bufferData.uv = this.gl.createBuffer();
+    }
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, renderer._bufferData.uv);
+    const textureNo: number = model.getDrawableTextureIndex(index);
+    const textureId: WebGLTexture = renderer
+      .getBindedTextures()
+      .getValue(textureNo);
+    this.gl.activeTexture(this.gl.TEXTURE0);
+    this.gl.bindTexture(this.gl.TEXTURE_2D, textureId);
+    this.gl.uniform1i(shaderSet.samplerTexture0Location, 0);
+
+    // テクスチャ頂点の設定
+    if (renderer._bufferData.uv == null) {
+      renderer._bufferData.uv = this.gl.createBuffer();
+    }
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, renderer._bufferData.uv);
+    const uvArray: Float32Array = model.getDrawableVertexUvs(index);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, uvArray, this.gl.DYNAMIC_DRAW);
+    this.gl.enableVertexAttribArray(shaderSet.attributeTexCoordLocation);
+    this.gl.vertexAttribPointer(
+      shaderSet.attributeTexCoordLocation,
+      2,
+      this.gl.FLOAT,
+      false,
+      0,
+      0
+    );
+
+    // チャンネル
+    const context = renderer.getClippingContextBufferForMask();
+    const channelNo: number =
+      renderer.getClippingContextBufferForMask()._layoutChannelNo;
+    const colorChannel: CubismTextureColor = renderer
+      .getClippingContextBufferForMask()
+      .getClippingManager()
+      .getChannelFlagAsColor(channelNo);
+    this.gl.uniform4f(
+      shaderSet.uniformChannelFlagLocation,
+      colorChannel.R,
+      colorChannel.G,
+      colorChannel.B,
+      colorChannel.A
+    );
+
+    this.gl.uniformMatrix4fv(
+      shaderSet.uniformClipMatrixLocation,
+      false,
+      renderer.getClippingContextBufferForMask()._matrixForMask.getArray()
+    );
+
+    const rect: csmRect =
+      renderer.getClippingContextBufferForMask()._layoutBounds;
+
+    this.gl.uniform4f(
+      shaderSet.uniformBaseColorLocation,
+      rect.x * 2.0 - 1.0,
+      rect.y * 2.0 - 1.0,
+      rect.getRight() * 2.0 - 1.0,
+      rect.getBottom() * 2.0 - 1.0
+    );
+
+    const multiplyColor: CubismTextureColor = model.getMultiplyColor(index);
+    const screenColor: CubismTextureColor = model.getScreenColor(index);
+
+    this.gl.uniform4f(
+      shaderSet.uniformMultiplyColorLocation,
+      multiplyColor.R,
+      multiplyColor.G,
+      multiplyColor.B,
+      multiplyColor.A
+    );
+
+    this.gl.uniform4f(
+      shaderSet.uniformScreenColorLocation,
+      screenColor.R,
+      screenColor.G,
+      screenColor.B,
+      screenColor.A
+    );
+
+    SRC_COLOR = this.gl.ZERO;
+    DST_COLOR = this.gl.ONE_MINUS_SRC_COLOR;
+    SRC_ALPHA = this.gl.ZERO;
+    DST_ALPHA = this.gl.ONE_MINUS_SRC_ALPHA;
+
+    // IBOを作成し、データを転送
+    if (renderer._bufferData.index == null) {
+      renderer._bufferData.index = this.gl.createBuffer();
+    }
+    const indexArray: Uint16Array = model.getDrawableVertexIndices(index);
+
+    this.gl.bindBuffer(
+      this.gl.ELEMENT_ARRAY_BUFFER,
+      renderer._bufferData.index
+    );
+    this.gl.bufferData(
+      this.gl.ELEMENT_ARRAY_BUFFER,
+      indexArray,
+      this.gl.DYNAMIC_DRAW
+    );
+
+    this.gl.blendFuncSeparate(SRC_COLOR, DST_COLOR, SRC_ALPHA, DST_ALPHA);
+  }
+
+  /**
+   * シェーダープログラムを解放する
+   */
+  public releaseShaderProgram(): void {
+    for (let i = 0; i < this._shaderSets.getSize(); i++) {
+      this.gl.deleteProgram(this._shaderSets.at(i).shaderProgram);
+      this._shaderSets.at(i).shaderProgram = 0;
+      this._shaderSets.set(i, void 0);
+      this._shaderSets.set(i, null);
+    }
+  }
+
+  /**
+   * シェーダープログラムを初期化する
+   * @param vertShaderSrc 頂点シェーダのソース
+   * @param fragShaderSrc フラグメントシェーダのソース
+   */
+  public generateShaders(): void {
+    for (let i = 0; i < ShaderCount; i++) {
+      this._shaderSets.pushBack(new CubismShaderSet());
+    }
+
+    this._shaderSets.at(0).shaderProgram = this.loadShaderProgram(
+      vertexShaderSrcSetupMask,
+      fragmentShaderSrcsetupMask
+    );
+
+    this._shaderSets.at(1).shaderProgram = this.loadShaderProgram(
+      vertexShaderSrc,
+      fragmentShaderSrcPremultipliedAlpha
+    );
+    this._shaderSets.at(2).shaderProgram = this.loadShaderProgram(
+      vertexShaderSrcMasked,
+      fragmentShaderSrcMaskPremultipliedAlpha
+    );
+    this._shaderSets.at(3).shaderProgram = this.loadShaderProgram(
+      vertexShaderSrcMasked,
+      fragmentShaderSrcMaskInvertedPremultipliedAlpha
+    );
+
+    // 加算も通常と同じシェーダーを利用する
+    this._shaderSets.at(4).shaderProgram = this._shaderSets.at(1).shaderProgram;
+    this._shaderSets.at(5).shaderProgram = this._shaderSets.at(2).shaderProgram;
+    this._shaderSets.at(6).shaderProgram = this._shaderSets.at(3).shaderProgram;
+
+    // 乗算も通常と同じシェーダーを利用する
+    this._shaderSets.at(7).shaderProgram = this._shaderSets.at(1).shaderProgram;
+    this._shaderSets.at(8).shaderProgram = this._shaderSets.at(2).shaderProgram;
+    this._shaderSets.at(9).shaderProgram = this._shaderSets.at(3).shaderProgram;
+
+    // SetupMask
+    this._shaderSets.at(0).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(0).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(0).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(0).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(0).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(0).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(0).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(0).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(0).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(0).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 通常（PremultipliedAlpha）
+    this._shaderSets.at(1).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(1).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(1).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(1).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(1).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(1).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(1).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(1).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(1).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(1).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(1).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(1).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(1).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(1).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 通常（クリッピング、PremultipliedAlpha）
+    this._shaderSets.at(2).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(2).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(2).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(2).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(2).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(2).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(2).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(2).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(2).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(2).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(2).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(2).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(2).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(2).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 通常（クリッピング・反転, PremultipliedAlpha）
+    this._shaderSets.at(3).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(3).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(3).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(3).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(3).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(3).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(3).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(3).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(3).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(3).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(3).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(3).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(3).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(3).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 加算（PremultipliedAlpha）
+    this._shaderSets.at(4).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(4).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(4).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(4).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(4).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(4).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(4).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(4).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(4).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(4).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(4).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(4).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(4).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(4).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 加算（クリッピング、PremultipliedAlpha）
+    this._shaderSets.at(5).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(5).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(5).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(5).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(5).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(5).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(5).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(5).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(5).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(5).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(5).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(5).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(5).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(5).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 加算（クリッピング・反転、PremultipliedAlpha）
+    this._shaderSets.at(6).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(6).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(6).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(6).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(6).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(6).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(6).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(6).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(6).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(6).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(6).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(6).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(6).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(6).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 乗算（PremultipliedAlpha）
+    this._shaderSets.at(7).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(7).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(7).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(7).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(7).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(7).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(7).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(7).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(7).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(7).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(7).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(7).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(7).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(7).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 乗算（クリッピング、PremultipliedAlpha）
+    this._shaderSets.at(8).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(8).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(8).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(8).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(8).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(8).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(8).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(8).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(8).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(8).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(8).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(8).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(8).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(8).shaderProgram,
+        'u_screenColor'
+      );
+
+    // 乗算（クリッピング・反転、PremultipliedAlpha）
+    this._shaderSets.at(9).attributePositionLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'a_position'
+      );
+    this._shaderSets.at(9).attributeTexCoordLocation =
+      this.gl.getAttribLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'a_texCoord'
+      );
+    this._shaderSets.at(9).samplerTexture0Location = this.gl.getUniformLocation(
+      this._shaderSets.at(9).shaderProgram,
+      's_texture0'
+    );
+    this._shaderSets.at(9).samplerTexture1Location = this.gl.getUniformLocation(
+      this._shaderSets.at(9).shaderProgram,
+      's_texture1'
+    );
+    this._shaderSets.at(9).uniformMatrixLocation = this.gl.getUniformLocation(
+      this._shaderSets.at(9).shaderProgram,
+      'u_matrix'
+    );
+    this._shaderSets.at(9).uniformClipMatrixLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'u_clipMatrix'
+      );
+    this._shaderSets.at(9).uniformChannelFlagLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'u_channelFlag'
+      );
+    this._shaderSets.at(9).uniformBaseColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'u_baseColor'
+      );
+    this._shaderSets.at(9).uniformMultiplyColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'u_multiplyColor'
+      );
+    this._shaderSets.at(9).uniformScreenColorLocation =
+      this.gl.getUniformLocation(
+        this._shaderSets.at(9).shaderProgram,
+        'u_screenColor'
+      );
+  }
+
+  /**
+   * シェーダプログラムをロードしてアドレスを返す
+   * @param vertexShaderSource    頂点シェーダのソース
+   * @param fragmentShaderSource  フラグメントシェーダのソース
+   * @return シェーダプログラムのアドレス
+   */
+  public loadShaderProgram(
+    vertexShaderSource: string,
+    fragmentShaderSource: string
+  ): WebGLProgram {
+    // Create Shader Program
+    let shaderProgram: WebGLProgram = this.gl.createProgram();
+
+    let vertShader = this.compileShaderSource(
+      this.gl.VERTEX_SHADER,
+      vertexShaderSource
+    );
+
+    if (!vertShader) {
+      CubismLogError('Vertex shader compile error!');
+      return 0;
+    }
+
+    let fragShader = this.compileShaderSource(
+      this.gl.FRAGMENT_SHADER,
+      fragmentShaderSource
+    );
+    if (!fragShader) {
+      CubismLogError('Vertex shader compile error!');
+      return 0;
+    }
+
+    // Attach vertex shader to program
+    this.gl.attachShader(shaderProgram, vertShader);
+
+    // Attach fragment shader to program
+    this.gl.attachShader(shaderProgram, fragShader);
+
+    // link program
+    this.gl.linkProgram(shaderProgram);
+    const linkStatus = this.gl.getProgramParameter(
+      shaderProgram,
+      this.gl.LINK_STATUS
+    );
+
+    // リンクに失敗したらシェーダーを削除
+    if (!linkStatus) {
+      CubismLogError('Failed to link program: {0}', shaderProgram);
+
+      this.gl.deleteShader(vertShader);
+      vertShader = 0;
+
+      this.gl.deleteShader(fragShader);
+      fragShader = 0;
+
+      if (shaderProgram) {
+        this.gl.deleteProgram(shaderProgram);
+        shaderProgram = 0;
+      }
+
+      return 0;
+    }
+
+    // Release vertex and fragment shaders.
+    this.gl.deleteShader(vertShader);
+    this.gl.deleteShader(fragShader);
+
+    return shaderProgram;
+  }
+
+  /**
+   * シェーダープログラムをコンパイルする
+   * @param shaderType シェーダタイプ(Vertex/Fragment)
+   * @param shaderSource シェーダソースコード
+   *
+   * @return コンパイルされたシェーダープログラム
+   */
+  public compileShaderSource(
+    shaderType: GLenum,
+    shaderSource: string
+  ): WebGLProgram {
+    const source: string = shaderSource;
+
+    const shader: WebGLProgram = this.gl.createShader(shaderType);
+    this.gl.shaderSource(shader, source);
+    this.gl.compileShader(shader);
+
+    if (!shader) {
+      const log: string = this.gl.getShaderInfoLog(shader);
+      CubismLogError('Shader compile log: {0} ', log);
+    }
+
+    const status: any = this.gl.getShaderParameter(
+      shader,
+      this.gl.COMPILE_STATUS
+    );
+    if (!status) {
+      this.gl.deleteShader(shader);
+      return null;
+    }
+
+    return shader;
+  }
+
+  public setGl(gl: WebGLRenderingContext): void {
+    this.gl = gl;
+  }
+
+  _shaderSets: csmVector<CubismShaderSet>; // ロードしたシェーダープログラムを保持する変数
+  gl: WebGLRenderingContext; // webglコンテキスト
+}
+
+/**
+ * CubismShader_WebGLのインナークラス
+ */
+export class CubismShaderSet {
+  shaderProgram: WebGLProgram; // シェーダープログラムのアドレス
+  attributePositionLocation: GLuint; // シェーダープログラムに渡す変数のアドレス（Position）
+  attributeTexCoordLocation: GLuint; // シェーダープログラムに渡す変数のアドレス（TexCoord）
+  uniformMatrixLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（Matrix）
+  uniformClipMatrixLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（ClipMatrix）
+  samplerTexture0Location: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（Texture0）
+  samplerTexture1Location: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（Texture1）
+  uniformBaseColorLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（BaseColor）
+  uniformChannelFlagLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（ChannelFlag）
+  uniformMultiplyColorLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（MultiplyColor）
+  uniformScreenColorLocation: WebGLUniformLocation; // シェーダープログラムに渡す変数のアドレス（ScreenColor）
+}
+
+export enum ShaderNames {
+  // SetupMask
+  ShaderNames_SetupMask,
+
+  // Normal
+  ShaderNames_NormalPremultipliedAlpha,
+  ShaderNames_NormalMaskedPremultipliedAlpha,
+  ShaderNames_NomralMaskedInvertedPremultipliedAlpha,
+
+  // Add
+  ShaderNames_AddPremultipliedAlpha,
+  ShaderNames_AddMaskedPremultipliedAlpha,
+  ShaderNames_AddMaskedPremultipliedAlphaInverted,
+
+  // Mult
+  ShaderNames_MultPremultipliedAlpha,
+  ShaderNames_MultMaskedPremultipliedAlpha,
+  ShaderNames_MultMaskedPremultipliedAlphaInverted
+}
+
+export const vertexShaderSrcSetupMask =
+  'attribute vec4     a_position;' +
+  'attribute vec2     a_texCoord;' +
+  'varying vec2       v_texCoord;' +
+  'varying vec4       v_myPos;' +
+  'uniform mat4       u_clipMatrix;' +
+  'void main()' +
+  '{' +
+  '   gl_Position = u_clipMatrix * a_position;' +
+  '   v_myPos = u_clipMatrix * a_position;' +
+  '   v_texCoord = a_texCoord;' +
+  '   v_texCoord.y = 1.0 - v_texCoord.y;' +
+  '}';
+
+export const fragmentShaderSrcsetupMask =
+  'precision mediump float;' +
+  'varying vec2       v_texCoord;' +
+  'varying vec4       v_myPos;' +
+  'uniform vec4       u_baseColor;' +
+  'uniform vec4       u_channelFlag;' +
+  'uniform sampler2D  s_texture0;' +
+  'void main()' +
+  '{' +
+  '   float isInside = ' +
+  '       step(u_baseColor.x, v_myPos.x/v_myPos.w)' +
+  '       * step(u_baseColor.y, v_myPos.y/v_myPos.w)' +
+  '       * step(v_myPos.x/v_myPos.w, u_baseColor.z)' +
+  '       * step(v_myPos.y/v_myPos.w, u_baseColor.w);' +
+  '   gl_FragColor = u_channelFlag * texture2D(s_texture0, v_texCoord).a * isInside;' +
+  '}';
+
+//----- バーテックスシェーダプログラム -----
+// Normal & Add & Mult 共通
+export const vertexShaderSrc =
+  'attribute vec4     a_position;' + //v.vertex
+  'attribute vec2     a_texCoord;' + //v.texcoord
+  'varying vec2       v_texCoord;' + //v2f.texcoord
+  'uniform mat4       u_matrix;' +
+  'void main()' +
+  '{' +
+  '   gl_Position = u_matrix * a_position;' +
+  '   v_texCoord = a_texCoord;' +
+  '   v_texCoord.y = 1.0 - v_texCoord.y;' +
+  '}';
+
+// Normal & Add & Mult 共通（クリッピングされたものの描画用）
+export const vertexShaderSrcMasked =
+  'attribute vec4     a_position;' +
+  'attribute vec2     a_texCoord;' +
+  'varying vec2       v_texCoord;' +
+  'varying vec4       v_clipPos;' +
+  'uniform mat4       u_matrix;' +
+  'uniform mat4       u_clipMatrix;' +
+  'void main()' +
+  '{' +
+  '   gl_Position = u_matrix * a_position;' +
+  '   v_clipPos = u_clipMatrix * a_position;' +
+  '   v_texCoord = a_texCoord;' +
+  '   v_texCoord.y = 1.0 - v_texCoord.y;' +
+  '}';
+
+//----- フラグメントシェーダプログラム -----
+// Normal & Add & Mult 共通 （PremultipliedAlpha）
+export const fragmentShaderSrcPremultipliedAlpha =
+  'precision mediump float;' +
+  'varying vec2       v_texCoord;' + //v2f.texcoord
+  'uniform vec4       u_baseColor;' +
+  'uniform sampler2D  s_texture0;' + //_MainTex
+  'uniform vec4       u_multiplyColor;' +
+  'uniform vec4       u_screenColor;' +
+  'void main()' +
+  '{' +
+  '   vec4 texColor = texture2D(s_texture0, v_texCoord);' +
+  '   texColor.rgb = texColor.rgb * u_multiplyColor.rgb;' +
+  '   texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);' +
+  '   vec4 color = texColor * u_baseColor;' +
+  '   gl_FragColor = vec4(color.rgb, color.a);' +
+  '}';
+
+// Normal （クリッピングされたものの描画用、PremultipliedAlpha兼用）
+export const fragmentShaderSrcMaskPremultipliedAlpha =
+  'precision mediump float;' +
+  'varying vec2       v_texCoord;' +
+  'varying vec4       v_clipPos;' +
+  'uniform vec4       u_baseColor;' +
+  'uniform vec4       u_channelFlag;' +
+  'uniform sampler2D  s_texture0;' +
+  'uniform sampler2D  s_texture1;' +
+  'uniform vec4       u_multiplyColor;' +
+  'uniform vec4       u_screenColor;' +
+  'void main()' +
+  '{' +
+  '   vec4 texColor = texture2D(s_texture0, v_texCoord);' +
+  '   texColor.rgb = texColor.rgb * u_multiplyColor.rgb;' +
+  '   texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);' +
+  '   vec4 col_formask = texColor * u_baseColor;' +
+  '   vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;' +
+  '   float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;' +
+  '   col_formask = col_formask * maskVal;' +
+  '   gl_FragColor = col_formask;' +
+  '}';
+
+// Normal & Add & Mult 共通（クリッピングされて反転使用の描画用、PremultipliedAlphaの場合）
+export const fragmentShaderSrcMaskInvertedPremultipliedAlpha =
+  'precision mediump float;' +
+  'varying vec2      v_texCoord;' +
+  'varying vec4      v_clipPos;' +
+  'uniform sampler2D s_texture0;' +
+  'uniform sampler2D s_texture1;' +
+  'uniform vec4      u_channelFlag;' +
+  'uniform vec4      u_baseColor;' +
+  'uniform vec4      u_multiplyColor;' +
+  'uniform vec4      u_screenColor;' +
+  'void main()' +
+  '{' +
+  '   vec4 texColor = texture2D(s_texture0, v_texCoord);' +
+  '   texColor.rgb = texColor.rgb * u_multiplyColor.rgb;' +
+  '   texColor.rgb = (texColor.rgb + u_screenColor.rgb * texColor.a) - (texColor.rgb * u_screenColor.rgb);' +
+  '   vec4 col_formask = texColor * u_baseColor;' +
+  '   vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;' +
+  '   float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;' +
+  '   col_formask = col_formask * (1.0 - maskVal);' +
+  '   gl_FragColor = col_formask;' +
+  '}';
+
+// Namespace definition for compatibility.
+import * as $ from './cubismshader_webgl';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismShaderSet = $.CubismShaderSet;
+  export type CubismShaderSet = $.CubismShaderSet;
+  export const CubismShader_WebGL = $.CubismShader_WebGL;
+  export type CubismShader_WebGL = $.CubismShader_WebGL;
+  export const ShaderNames = $.ShaderNames;
+  export type ShaderNames = $.ShaderNames;
+}

--- a/src/utils/cubismdebug.ts
+++ b/src/utils/cubismdebug.ts
@@ -11,7 +11,7 @@ import {
   CSM_LOG_LEVEL_ERROR,
   CSM_LOG_LEVEL_INFO,
   CSM_LOG_LEVEL_VERBOSE,
-  CSM_LOG_LEVEL_WARNING,
+  CSM_LOG_LEVEL_WARNING
 } from '../cubismframeworkconfig';
 import { CubismFramework, LogLevel } from '../live2dcubismframework';
 

--- a/src/utils/cubismjsonextension.ts
+++ b/src/utils/cubismjsonextension.ts
@@ -12,7 +12,7 @@ import {
   JsonMap,
   JsonNullvalue,
   JsonString,
-  Value,
+  Value
 } from './cubismjson';
 
 /**


### PR DESCRIPTION
### Added

* Add the function to get the ID of a given parameter.(`CubismModel.getParameterId`)
* Add the `CubismExpressionMotionManager` class.

### Changed

* Change the visibility of the `CubismId` constructor to private.
  * Please use `CubismFramework.getIdManager().getId()` to get `CubismId`.
* Change the word `DrawMesh` to `DrawMeshWebGL`.

### Fixed

* Fix a bug that the value applied by multiply was not appropriate during expression transitions.
* Fix the structure of the class in renderer.
* Fix a issue where `ARRAY_BUFFER` was used on multiple targets.
* Separate shader class from `cubismrenderer` class.
* Separate the high precision mask process from the clipping mask setup process.

### Removed

* Remove several arguments of `DrawMesh` function.