### PR TITLE
Improve CubismJson

### DIFF
--- a/src/cubismmodelsettingjson.ts
+++ b/src/cubismmodelsettingjson.ts
@@ -92,8 +92,6 @@ export class CubismModelSettingJson extends ICubismModelSetting {
    * デストラクタ相当の処理
    */
   public release(): void {
-    CubismJson.delete(this._json);
-
     this._jsonValue = null;
   }
 

--- a/src/effect/cubismpose.ts
+++ b/src/effect/cubismpose.ts
@@ -96,8 +96,6 @@ export class CubismPose {
       ret._partGroupCounts.pushBack(groupCount);
     }
 
-    CubismJson.delete(json);
-
     return ret;
   }
 

--- a/src/model/cubismmodeluserdata.ts
+++ b/src/model/cubismmodeluserdata.ts
@@ -78,7 +78,6 @@ export class CubismModelUserData {
       size
     );
     if (!json) {
-      json.release();
       json = void 0;
       return;
     }
@@ -101,7 +100,6 @@ export class CubismModelUserData {
       }
     }
 
-    json.release();
     json = void 0;
   }
 

--- a/src/model/cubismmodeluserdatajson.ts
+++ b/src/model/cubismmodeluserdatajson.ts
@@ -28,13 +28,6 @@ export class CubismModelUserDataJson {
   }
 
   /**
-   * デストラクタ相当の処理
-   */
-  public release(): void {
-    CubismJson.delete(this._json);
-  }
-
-  /**
    * ユーザーデータ個数の取得
    * @return ユーザーデータの個数
    */

--- a/src/motion/cubismexpressionmotion.ts
+++ b/src/motion/cubismexpressionmotion.ts
@@ -318,8 +318,6 @@ export class CubismExpressionMotion extends ACubismMotion {
 
       this._parameters.pushBack(item);
     }
-
-    CubismJson.delete(json); // JSONデータは不要になったら削除する
   }
 
   /**

--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -846,7 +846,6 @@ export class CubismMotion extends ACubismMotion {
    * デストラクタ相当の処理
    */
   public release(): void {
-    this._motionData = void 0;
     this._motionData = null;
   }
 
@@ -900,7 +899,6 @@ export class CubismMotion extends ACubismMotion {
     let json: CubismMotionJson = new CubismMotionJson(motionJson, size);
 
     if (!json) {
-      json.release();
       json = void 0;
       return;
     }
@@ -908,7 +906,6 @@ export class CubismMotion extends ACubismMotion {
     if (shouldCheckMotionConsistency) {
       const consistency = json.hasConsistency();
       if (!consistency) {
-        json.release();
         CubismLogError('Inconsistent motion3.json.');
         return;
       }
@@ -1135,8 +1132,6 @@ export class CubismMotion extends ACubismMotion {
         json.getEventValue(userdatacount);
     }
 
-    json.release();
-    json = void 0;
     json = null;
   }
 

--- a/src/motion/cubismmotionjson.ts
+++ b/src/motion/cubismmotionjson.ts
@@ -47,13 +47,6 @@ export class CubismMotionJson {
   }
 
   /**
-   * デストラクタ相当の処理
-   */
-  public release(): void {
-    CubismJson.delete(this._json);
-  }
-
-  /**
    * モーションの長さを取得する
    * @return モーションの長さ[秒]
    */

--- a/src/physics/cubismphysics.ts
+++ b/src/physics/cubismphysics.ts
@@ -257,8 +257,6 @@ export class CubismPhysics {
 
     this.initialize();
 
-    json.release();
-    json = void 0;
     json = null;
   }
 
@@ -787,7 +785,6 @@ export class CubismPhysics {
    * デストラクタ相当の処理
    */
   public release(): void {
-    this._physicsRig = void 0;
     this._physicsRig = null;
   }
 

--- a/src/physics/cubismphysicsjson.ts
+++ b/src/physics/cubismphysicsjson.ts
@@ -69,13 +69,6 @@ export class CubismPhysicsJson {
   }
 
   /**
-   * デストラクタ相当の処理
-   */
-  public release(): void {
-    CubismJson.delete(this._json);
-  }
-
-  /**
    * 重力の取得
    * @return 重力
    */

--- a/src/rendering/cubismrenderer_webgl.ts
+++ b/src/rendering/cubismrenderer_webgl.ts
@@ -629,7 +629,6 @@ export class CubismRenderer_WebGL extends CubismRenderer {
 
     // FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
     this._clippingManager.release();
-    this._clippingManager = void 0;
     this._clippingManager = null;
 
     this._clippingManager = new CubismClippingManager_WebGL();
@@ -689,7 +688,6 @@ export class CubismRenderer_WebGL extends CubismRenderer {
   public release(): void {
     if (this._clippingManager) {
       this._clippingManager.release();
-      this._clippingManager = void 0;
       this._clippingManager = null;
     }
 

--- a/src/rendering/cubismrenderer_webgl.ts
+++ b/src/rendering/cubismrenderer_webgl.ts
@@ -629,7 +629,6 @@ export class CubismRenderer_WebGL extends CubismRenderer {
 
     // FrameBufferのサイズを変更するためにインスタンスを破棄・再作成する
     this._clippingManager.release();
-    this._clippingManager = null;
 
     this._clippingManager = new CubismClippingManager_WebGL();
 

--- a/src/rendering/cubismshader_webgl.ts
+++ b/src/rendering/cubismshader_webgl.ts
@@ -394,7 +394,6 @@ export class CubismShader_WebGL {
     for (let i = 0; i < this._shaderSets.getSize(); i++) {
       this.gl.deleteProgram(this._shaderSets.at(i).shaderProgram);
       this._shaderSets.at(i).shaderProgram = 0;
-      this._shaderSets.set(i, void 0);
       this._shaderSets.set(i, null);
     }
   }

--- a/src/type/csmmap.ts
+++ b/src/type/csmmap.ts
@@ -150,7 +150,6 @@ export class csmMap<_KeyT, _ValT> {
    * keyValueのポインタを全て解放する
    */
   public clear(): void {
-    this._keyValues = void 0;
     this._keyValues = null;
     this._keyValues = [];
 

--- a/src/type/csmmap.ts
+++ b/src/type/csmmap.ts
@@ -150,7 +150,6 @@ export class csmMap<_KeyT, _ValT> {
    * keyValueのポインタを全て解放する
    */
   public clear(): void {
-    this._keyValues = null;
     this._keyValues = [];
 
     this._size = 0;

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -256,21 +256,11 @@ export class CubismJson {
       json._parseCallback
     );
 
-    if (!succeeded) {
-      CubismJson.delete(json);
-      return null;
-    } else {
+    if (succeeded) {
       return json;
+    } else {
+      return null;
     }
-  }
-
-  /**
-   * パースしたJSONオブジェクトの解放処理
-   *
-   * @param instance CubismJsonクラスのインスタンス
-   */
-  public static delete(instance: CubismJson) {
-    instance = null;
   }
 
   /**
@@ -287,22 +277,7 @@ export class CubismJson {
    * @return 変換後の文字列
    */
   public static arrayBufferToString(buffer: ArrayBuffer): string {
-    const uint8Array: Uint8Array = new Uint8Array(buffer);
-    let str = '';
-
-    for (let i = 0, len: number = uint8Array.length; i < len; ++i) {
-      str += '%' + this.pad(uint8Array[i].toString(16));
-    }
-
-    str = decodeURIComponent(str);
-    return str;
-  }
-
-  /**
-   * エンコード、パディング
-   */
-  private static pad(n: string): string {
-    return n.length < 2 ? '0' + n : n;
+    return new TextDecoder('utf-8').decode(buffer);
   }
 
   /**
@@ -318,13 +293,13 @@ export class CubismJson {
     parseCallback?: parseJsonObject
   ): boolean {
     const endPos: number[] = new Array<number>(1); // 参照渡しにするため配列
-    const decodeBuffer: string = CubismJson.arrayBufferToString(buffer);
+    const decodedBuffer: string = CubismJson.arrayBufferToString(buffer);
 
     if (parseCallback == undefined) {
-      this._root = this.parseValue(decodeBuffer, size, 0, endPos);
+      this._root = this.parseValue(decodedBuffer, size, 0, endPos);
     } else {
       // TypeScript標準のJSONパーサを使う
-      this._root = parseCallback(JSON.parse(decodeBuffer), new JsonMap());
+      this._root = parseCallback(JSON.parse(decodedBuffer), new JsonMap());
     }
 
     if (this._error) {
@@ -1057,7 +1032,6 @@ export class JsonArray extends Value {
       let v: Value = ite.ptr();
 
       if (v && !v.isStatic()) {
-        v = void 0;
         v = null;
       }
     }
@@ -1165,7 +1139,6 @@ export class JsonMap extends Value {
       let v: Value = ite.ptr().second;
 
       if (v && !v.isStatic()) {
-        v = void 0;
         v = null;
       }
 


### PR DESCRIPTION
## Changes

As of today, [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder) is widely available and can be used to convert ArrayBuffer to a string. It is also faster than current implementation.

<details>
<summary>Benchmark Code</summary>

```ts
import { Bench } from 'tinybench'

const bench = new Bench({ name: 'decode bench', time: 1000 })

class CubismJson {
  public static arrayBufferToString(buffer: ArrayBuffer): string {
    const uint8Array: Uint8Array = new Uint8Array(buffer);
    let str = '';

    for (let i = 0, len: number = uint8Array.length; i < len; ++i) {
      str += '%' + this.pad(uint8Array[i].toString(16));
    }

    str = decodeURIComponent(str);
    return str;
  }

  /**
   * エンコード、パディング
   */
  private static pad(n: string): string {
    return n.length < 2 ? '0' + n : n;
  }
}

const get = () => new Uint8Array([99, 100, 124, 5, 6, 8, 13, 14, 44, 55, 89]).buffer

bench
  .add('arrayBufferToString', () => CubismJson.arrayBufferToString(get()))
  .add('TextDecoder', () => new TextDecoder('utf-8').decode(get()));

await bench.run()

console.table(bench.table())
```
</details>

<details>
<summary>Benchmark Results</summary>

![Screenshot](https://github.com/user-attachments/assets/fb1f8b8b-31fa-4bef-b3f4-6d78d5e93fdd)
</details>

Also, in this PR `delete` method in CubismJson is removed. It is misleading, as it does not actually delete anything. Local variable `instance` is changed to `null`. In JavaScript you can't clear resources this way. Functions that call `delete` method are also removed.

And also, the first assignment in duplicated assignments like below is removed.

```ts
this._clippingManager = void 0;
this._clippingManager = null;
```

As `void 0` is evaluated to `undefined`, property is replaced by `undefined` and then by `null`. It does not have sense to do it twice, just `undefined` or `null` or anything is enough to make garbage collector do it's job, all you need to leave no references to object you want to get rid of.

## Proposal
There are functions like `csmDelete` in `src/live2dcubismframework.ts` which also does nothing. Same as code below from `src/utils/cubismjson.ts`. 
```ts
let v: Value = ite.ptr();

if (v && !v.isStatic()) {
  v = null;
}
```
It does not remove any values, all it does is changes local variable to null. For proper clean up it should be `this._array.remove(i)` to actually remove item from array.