### PR TITLE
Update to Cubism 5 SDK for Web R5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## [5-r.5] - 2026-04-02
+
+### Added
+
+* Add functionality to change motion calculation order.
+* Add `cubismlook` class that implements the target tracking feature.
+  * The target tracking feature can now specify parameter IDs through the `Framework`.
+
+### Changed
+
+* Change multiply and screen color functions to separate class with renamed methods.
+
+### Fixed
+
+* Fix unnecessary multiply color and screen color settings in mask drawing.
+
+### Removed
+
+* Remove deprecated functions from CubismMotion:
+  * `setIsLoop()` (use `setLoop()` instead)
+  * `isLoop()` (use `getLoop()` instead)
+  * `setIsLoopFadeIn()` (use `setLoopFadeIn()` instead)
+  * `isLoopFadeIn()` (use `getLoopFadeIn()` instead)
+* Remove deprecated functions from CubismExpressionMotionManager:
+  * `getCurrentPriority()` (priority is not used in expression motion playback)
+  * `getReservePriority()` (priority is not used in expression motion playback)
+  * `setReservePriority()` (priority is not used in expression motion playback)
+  * `startMotionPriority()` (use `startMotion()` instead)
+* Remove deprecated fields from CubismExpressionMotionManager:
+  * `_currentPriority` (priority is not used in expression motion playback)
+  * `_reservePriority` (priority is not used in expression motion playback)
+* Remove deprecated function from CubismExpressionMotion:
+  * `getFadeWeight()` (use `CubismExpressionMotionManager.getFadeWeight()` instead)
+* Remove deprecated field from CubismExpressionMotion:
+  * `_fadeWeight` (can cause bugs)
+* Remove deprecated functions from CubismModel:
+  * `getOverwriteFlagForModelCullings()` (renamed to `getOverrideFlagForModelCullings()`)
+  * `setOverwriteFlagForModelCullings()` (renamed to `setOverrideFlagForModelCullings()`)
+  * `getOverwriteFlagForDrawableCullings()` (renamed to `getOverrideFlagForDrawableCullings()`)
+  * `setOverwriteFlagForDrawableCullings()` (renamed to `setOverrideFlagForDrawableCullings()`)
+
+
 ## [5-r.5-beta.3.1] - 2026-02-19
 
 ### Fixed
@@ -390,6 +433,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Reformat code using Prettier and ESLint.
 
 
+[5-r.5]: https://github.com/Live2D/CubismWebFramework/compare/5-r.5-beta.3.1...5-r.5
 [5-r.5-beta.3.1]: https://github.com/Live2D/CubismWebFramework/compare/5-r.5-beta.3...5-r.5-beta.3.1
 [5-r.5-beta.3]: https://github.com/Live2D/CubismWebFramework/compare/5-r.5-beta.2...5-r.5-beta.3
 [5-r.5-beta.2]: https://github.com/Live2D/CubismWebFramework/compare/5-r.5-beta.1...5-r.5-beta.2

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,8 +28,8 @@ Cubism 5.3 Editorに搭載された新機能のSDK対応については [こち�
 
 ### Node.js
 
-* 25.4.0
-* 24.13.0
+* 25.8.2
+* 24.14.1
 
 
 ### TypeScript
@@ -47,7 +47,7 @@ Cubism 5.3 Editorに搭載された新機能のSDK対応については [こち�
 
 コマンドパレットのタスク一覧から各種コマンドを実行することができます。
 
-NOTE: デバック用の設定は、`.vscode/tasks.json` に記述しています。
+NOTE: デバッグ用の設定は、`.vscode/tasks.json` に記述しています。
 
 ## タスク一覧
 
@@ -67,13 +67,13 @@ TypeScript の型チェックテストを行います。
 
 `src` ディレクトリ内の TypeScript ファイルの静的解析を行います。
 
-`.eslintrc.yml` を編集することで設定内容を変更できます。
+`eslint.config.mjs` を編集することで設定内容を変更できます。
 
 ### `npm: lint:fix`
 
 `src` ディレクトリ内の TypeScript ファイルの静的解析及び自動修正を行います。
 
-`.eslintrc.yml` を編集することで設定内容を変更できます。
+`eslint.config.mjs` を編集することで設定内容を変更できます。
 
 ### `npm: clean`
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ For compatibility with previous versions of Cubism SDK, please refer to [here](h
 
 ### Node.js
 
-* 25.4.0
-* 24.13.0
+* 25.8.2
+* 24.14.1
 
 
 ### TypeScript
@@ -67,13 +67,13 @@ You can change the settings by editing `tsconfig.json`.
 
 Performs static analysis of TypeScript files in the `src` directory.
 
-You can change the settings by editing `.eslintrc.yml`.
+You can change the settings by editing `eslint.config.mjs`.
 
 ### `npm: lint:fix`
 
 Performs static analysis and automatic modification of TypeScript files in the `src` directory.
 
-You can change the settings by editing `.eslintrc.yml`.
+You can change the settings by editing `eslint.config.mjs`.
 
 ### `npm: clean`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,15 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "Framework",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "prettier": "^3.8.1",
-        "rimraf": "^6.1.2",
+        "rimraf": "^6.1.3",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.53.1"
+        "typescript-eslint": "^8.57.2"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -212,29 +211,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -263,17 +239,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.1.tgz",
-      "integrity": "sha512-cFYYFZ+oQFi6hUnBTbLRXfTJiaQtYE3t4O692agbBl+2Zy+eqSKWtPjhPXJu1G7j4RLjKgeJPDdq3EqOwmX5Ag==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
+      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/type-utils": "8.53.1",
-        "@typescript-eslint/utils": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/type-utils": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -286,8 +262,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.53.1",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/parser": "^8.57.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -302,16 +278,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.1.tgz",
-      "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
+      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -322,19 +298,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
-      "integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
+      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
+        "@typescript-eslint/tsconfig-utils": "^8.57.2",
+        "@typescript-eslint/types": "^8.57.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -349,14 +325,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
-      "integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
+      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1"
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -367,9 +343,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
-      "integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
+      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -384,15 +360,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.1.tgz",
-      "integrity": "sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
+      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1",
-        "@typescript-eslint/utils": "8.53.1",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -404,14 +380,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
-      "integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
+      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -423,18 +399,18 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
-      "integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
+      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.53.1",
-        "@typescript-eslint/tsconfig-utils": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/visitor-keys": "8.53.1",
+        "@typescript-eslint/project-service": "8.57.2",
+        "@typescript-eslint/tsconfig-utils": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/visitor-keys": "8.57.2",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.4.0"
@@ -450,43 +426,56 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.1.tgz",
-      "integrity": "sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
+      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.53.1",
-        "@typescript-eslint/types": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1"
+        "@typescript-eslint/scope-manager": "8.57.2",
+        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -496,19 +485,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-      "integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
+      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.57.2",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -516,6 +505,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
@@ -542,9 +544,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -998,25 +1000,25 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1035,17 +1037,40 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1223,9 +1248,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1233,9 +1258,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1246,11 +1271,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -1360,9 +1385,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1370,16 +1395,16 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1449,13 +1474,13 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
-      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^13.0.0",
+        "glob": "^13.0.3",
         "package-json-from-dist": "^1.0.1"
       },
       "bin": {
@@ -1469,9 +1494,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1564,9 +1589,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1604,16 +1629,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.53.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.1.tgz",
-      "integrity": "sha512-gB+EVQfP5RDElh9ittfXlhZJdjSU4jUSTyE2+ia8CYyNvet4ElfaLlAIqDvQV9JPknKx0jQH1racTYe/4LaLSg==",
+      "version": "8.57.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
+      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.53.1",
-        "@typescript-eslint/parser": "8.53.1",
-        "@typescript-eslint/typescript-estree": "8.53.1",
-        "@typescript-eslint/utils": "8.53.1"
+        "@typescript-eslint/eslint-plugin": "8.57.2",
+        "@typescript-eslint/parser": "8.57.2",
+        "@typescript-eslint/typescript-estree": "8.57.2",
+        "@typescript-eslint/utils": "8.57.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1623,7 +1648,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "prettier": "^3.8.1",
-    "rimraf": "^6.1.2",
+    "rimraf": "^6.1.3",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.1"
+    "typescript-eslint": "^8.57.2"
   }
 }

--- a/src/effect/cubismlook.ts
+++ b/src/effect/cubismlook.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { CubismIdHandle } from '../id/cubismid';
+import { CubismModel } from '../model/cubismmodel';
+
+/**
+ * ターゲットによるパラメータ追従機能
+ *
+ * ドラッグ入力に対するパラメータ追従機能を提供する。
+ */
+export class CubismLook {
+  /**
+   * インスタンスの作成
+   */
+  public static create(): CubismLook {
+    return new CubismLook();
+  }
+
+  /**
+   * インスタンスの破棄
+   * @param instance 対象のCubismDrag
+   */
+  public static delete(instance: CubismLook): void {
+    if (instance != null) {
+      instance = null;
+    }
+  }
+
+  /**
+   * ターゲット追従のパラメータの紐づけ
+   * @param lookParameters ターゲット追従を紐づけたいパラメータのリスト
+   */
+  public setParameters(lookParameters: Array<LookParameterData>): void {
+    this._lookParameters = lookParameters;
+  }
+
+  /**
+   * ターゲット追従に紐づいているパラメータの取得
+   * @return ターゲット追従に紐づいているパラメータのリスト
+   */
+  public getParameters(): Array<LookParameterData> {
+    return this._lookParameters;
+  }
+
+  /**
+   * モデルのパラメータの更新
+   * @param model 対象のモデル
+   * @param dragX ターゲットのX座標
+   * @param dragY ターゲットのY座標
+   */
+  public updateParameters(
+    model: CubismModel,
+    dragX: number,
+    dragY: number
+  ): void {
+    for (let i = 0; i < this._lookParameters.length; ++i) {
+      const data: LookParameterData = this._lookParameters[i];
+
+      model.addParameterValueById(
+        data.parameterId,
+        data.factorX * dragX +
+          data.factorY * dragY +
+          data.factorXY * dragX * dragY
+      );
+    }
+  }
+
+  /**
+   * コンストラクタ
+   */
+  public constructor() {
+    this._lookParameters = new Array<LookParameterData>();
+  }
+
+  _lookParameters: Array<LookParameterData>; // ターゲット追従に紐づいているパラメータのリスト
+}
+
+/**
+ * ターゲット追従のパラメータ情報
+ */
+export class LookParameterData {
+  /**
+   * コンストラクタ
+   * @param parameterId   ターゲット追従を紐づけるパラメータID
+   * @param factorX       X方向ドラッグ入力に対する係数
+   * @param factorY       Y方向ドラッグ入力に対する係数
+   * @param factorXY      XY積ドラッグ入力に対する係数
+   */
+  constructor(
+    parameterId?: CubismIdHandle,
+    factorX?: number,
+    factorY?: number,
+    factorXY?: number
+  ) {
+    this.parameterId = parameterId == undefined ? null : parameterId;
+    this.factorX = factorX == undefined ? 0.0 : factorX;
+    this.factorY = factorY == undefined ? 0.0 : factorY;
+    this.factorXY = factorXY == undefined ? 0.0 : factorXY;
+  }
+
+  parameterId: CubismIdHandle; // ターゲット追従を紐づけるパラメータID
+  factorX: number; // X方向ドラッグ入力に対する係数
+  factorY: number; // Y方向ドラッグ入力に対する係数
+  factorXY: number; // XY積ドラッグ入力に対する係数
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismlook';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const LookParameterData = $.LookParameterData;
+  export type LookParameterData = $.LookParameterData;
+  export const CubismLook = $.CubismLook;
+  export type CubismLook = $.CubismLook;
+}

--- a/src/model/cubismmodel.ts
+++ b/src/model/cubismmodel.ts
@@ -12,7 +12,8 @@ import {
   CubismBlendMode,
   CubismTextureColor
 } from '../rendering/cubismrenderer';
-import { CSM_ASSERT, CubismLogWarning } from '../utils/cubismdebug';
+import { CSM_ASSERT } from '../utils/cubismdebug';
+import { CubismModelMultiplyAndScreenColor } from './cubismmodelmultiplyandscreencolor';
 
 export const NoParentIndex = -1; // 親が取得できない場合の値を表す定数
 export const NoOffscreenIndex = -1; // オフスクリーンが取得できない場合の値を表す定数
@@ -89,64 +90,6 @@ export class ParameterRepeatData {
    * Override flag for settings
    */
   public isParameterRepeated: boolean;
-}
-
-/**
- * (deprecated) SDK側から与えられたDrawableの乗算色・スクリーン色上書きフラグと
- * その色を保持する構造体
- */
-export class DrawableColorData {
-  constructor(
-    isOverridden = false,
-    color: CubismTextureColor = new CubismTextureColor()
-  ) {
-    this.isOverridden = isOverridden;
-    this.color = color;
-  }
-
-  public isOverridden: boolean;
-  public color: CubismTextureColor;
-
-  get isOverwritten(): boolean {
-    return this.isOverridden;
-  }
-}
-
-/**
- * (deprecated) テクスチャの色をRGBAで扱うための構造体
- */
-export class PartColorData {
-  constructor(
-    isOverridden = false,
-    color: CubismTextureColor = new CubismTextureColor()
-  ) {
-    this.isOverridden = isOverridden;
-    this.color = color;
-  }
-
-  public isOverridden: boolean;
-  public color: CubismTextureColor;
-
-  get isOverwritten(): boolean {
-    return this.isOverridden;
-  }
-}
-
-/**
- * SDK側から与えられた描画オブジェクトの乗算色・スクリーン色上書きフラグと
- * その色を保持する構造体
- */
-export class ColorData {
-  constructor(
-    isOverridden = false,
-    color: CubismTextureColor = new CubismTextureColor()
-  ) {
-    this.isOverridden = isOverridden;
-    this.color = color;
-  }
-
-  public isOverridden: boolean;
-  public color: CubismTextureColor;
 }
 
 /**
@@ -312,383 +255,12 @@ export class CubismModel {
   }
 
   /**
-   * Drawableの乗算色を取得する
+   * 乗算色・スクリーン色管理クラスを取得する
    *
-   * @param drawableIndex Drawableのインデックス
-   *
-   * @return 指定した描画オブジェクトの乗算色(RGBA)
+   * @return CubismModelMultiplyAndScreenColorのインスタンス
    */
-  public getMultiplyColor(drawableIndex: number): CubismTextureColor {
-    if (
-      this.getOverrideFlagForModelMultiplyColors() ||
-      this.getOverrideFlagForDrawableMultiplyColors(drawableIndex)
-    ) {
-      return this._userDrawableMultiplyColors[drawableIndex].color;
-    }
-    return this.getDrawableMultiplyColor(drawableIndex);
-  }
-
-  /**
-   * Drawableのスクリーン色を取得する
-   *
-   * @param drawableIndex Drawableのインデックス
-   *
-   * @return 指定した描画オブジェクトのスクリーン色(RGBA)
-   */
-  public getScreenColor(drawableIndex: number): CubismTextureColor {
-    if (
-      this.getOverrideFlagForModelScreenColors() ||
-      this.getOverrideFlagForDrawableScreenColors(drawableIndex)
-    ) {
-      return this._userDrawableScreenColors[drawableIndex].color;
-    }
-    return this.getDrawableScreenColor(drawableIndex);
-  }
-
-  /**
-   * Drawableの乗算色をセットする
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @param color 設定する乗算色(CubismTextureColor)
-   */
-  public setMultiplyColorByTextureColor(
-    drawableIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setMultiplyColorByRGBA(
-      drawableIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * Drawableの乗算色をセットする
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @param r 設定する乗算色のR値
-   * @param g 設定する乗算色のG値
-   * @param b 設定する乗算色のB値
-   * @param a 設定する乗算色のA値
-   */
-  public setMultiplyColorByRGBA(
-    drawableIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a = 1.0
-  ) {
-    this._userDrawableMultiplyColors[drawableIndex].color.r = r;
-    this._userDrawableMultiplyColors[drawableIndex].color.g = g;
-    this._userDrawableMultiplyColors[drawableIndex].color.b = b;
-    this._userDrawableMultiplyColors[drawableIndex].color.a = a;
-  }
-
-  /**
-   * Drawableのスクリーン色をセットする
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @param color 設定するスクリーン色(CubismTextureColor)
-   */
-  public setScreenColorByTextureColor(
-    drawableIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setScreenColorByRGBA(
-      drawableIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * Drawableのスクリーン色をセットする
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @param r 設定するスクリーン色のR値
-   * @param g 設定するスクリーン色のG値
-   * @param b 設定するスクリーン色のB値
-   * @param a 設定するスクリーン色のA値
-   */
-  public setScreenColorByRGBA(
-    drawableIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a = 1.0
-  ) {
-    this._userDrawableScreenColors[drawableIndex].color.r = r;
-    this._userDrawableScreenColors[drawableIndex].color.g = g;
-    this._userDrawableScreenColors[drawableIndex].color.b = b;
-    this._userDrawableScreenColors[drawableIndex].color.a = a;
-  }
-
-  /**
-   * partの乗算色を取得する
-   *
-   * @param partIndex partのインデックス
-   * @return 指定したpartの乗算色
-   */
-  public getPartMultiplyColor(partIndex: number): CubismTextureColor {
-    return this._userPartMultiplyColors[partIndex].color;
-  }
-
-  /**
-   * partのスクリーン色を取得する
-   *
-   * @param partIndex partのインデックス
-   * @return 指定したpartのスクリーン色
-   */
-  public getPartScreenColor(partIndex: number): CubismTextureColor {
-    return this._userPartScreenColors[partIndex].color;
-  }
-
-  /**
-   * partのOverrideColor setter関数
-   *
-   * @param partIndex partのインデックス
-   * @param r 設定する色のR値
-   * @param g 設定する色のG値
-   * @param b 設定する色のB値
-   * @param a 設定する色のA値
-   * @param partColors 設定するpartのカラーデータ配列
-   * @param drawableColors partに関連するDrawableのカラーデータ配列
-   */
-  public setPartColor(
-    partIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a: number,
-    partColors: Array<ColorData>,
-    drawableColors: Array<ColorData>
-  ) {
-    partColors[partIndex].color.r = r;
-    partColors[partIndex].color.g = g;
-    partColors[partIndex].color.b = b;
-    partColors[partIndex].color.a = a;
-
-    if (partColors[partIndex].isOverridden) {
-      for (let i = 0; i < this._partChildDrawables[partIndex].length; ++i) {
-        const drawableIndex = this._partChildDrawables[partIndex][i];
-        drawableColors[drawableIndex].color.r = r;
-        drawableColors[drawableIndex].color.g = g;
-        drawableColors[drawableIndex].color.b = b;
-        drawableColors[drawableIndex].color.a = a;
-      }
-    }
-  }
-
-  /**
-   * 乗算色をセットする
-   *
-   * @param partIndex partのインデックス
-   * @param color 設定する乗算色(CubismTextureColor)
-   */
-  public setPartMultiplyColorByTextureColor(
-    partIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setPartMultiplyColorByRGBA(
-      partIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * 乗算色をセットする
-   *
-   * @param partIndex partのインデックス
-   * @param r 設定する乗算色のR値
-   * @param g 設定する乗算色のG値
-   * @param b 設定する乗算色のB値
-   * @param a 設定する乗算色のA値
-   */
-  public setPartMultiplyColorByRGBA(
-    partIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a: number
-  ) {
-    this.setPartColor(
-      partIndex,
-      r,
-      g,
-      b,
-      a,
-      this._userPartMultiplyColors,
-      this._userDrawableMultiplyColors
-    );
-  }
-
-  /**
-   * スクリーン色をセットする
-   *
-   * @param partIndex partのインデックス
-   * @param color 設定するスクリーン色(CubismTextureColor)
-   */
-  public setPartScreenColorByTextureColor(
-    partIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setPartScreenColorByRGBA(
-      partIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * スクリーン色をセットする
-   *
-   * @param partIndex partのインデックス
-   * @param r 設定するスクリーン色のR値
-   * @param g 設定するスクリーン色のG値
-   * @param b 設定するスクリーン色のB値
-   * @param a 設定するスクリーン色のA値
-   */
-  public setPartScreenColorByRGBA(
-    partIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a: number
-  ) {
-    this.setPartColor(
-      partIndex,
-      r,
-      g,
-      b,
-      a,
-      this._userPartScreenColors,
-      this._userDrawableScreenColors
-    );
-  }
-
-  /**
-   * Offscreenの乗算色を取得する
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   *
-   * @return 指定した描画オブジェクトの乗算色(RGBA)
-   */
-  public getMultiplyColorOffscreen(offscreenIndex: number): CubismTextureColor {
-    if (
-      this.getOverrideFlagForModelMultiplyColors() ||
-      this.getOverrideFlagForOffscreenMultiplyColors(offscreenIndex)
-    ) {
-      return this._userOffscreenMultiplyColors[offscreenIndex].color;
-    }
-    return this.getOffscreenMultiplyColor(offscreenIndex);
-  }
-
-  /**
-   * Offscreenのスクリーン色を取得する
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   *
-   * @return 指定した描画オブジェクトのスクリーン色(RGBA)
-   */
-  public getScreenColorOffscreen(offscreenIndex: number): CubismTextureColor {
-    if (
-      this.getOverrideFlagForModelScreenColors() ||
-      this.getOverrideFlagForOffscreenScreenColors(offscreenIndex)
-    ) {
-      return this._userOffscreenScreenColors[offscreenIndex].color;
-    }
-    return this.getOffscreenScreenColor(offscreenIndex);
-  }
-
-  /**
-   * Offscreenの乗算色をセットする
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   * @param color 設定する乗算色(CubismTextureColor)
-   */
-  public setMultiplyColorByTextureColorOffscreen(
-    offscreenIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setMultiplyColorByRGBAOffscreen(
-      offscreenIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * Offscreenの乗算色をセットする
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   * @param r 設定する乗算色のR値
-   * @param g 設定する乗算色のG値
-   * @param b 設定する乗算色のB値
-   * @param a 設定する乗算色のA値
-   */
-  public setMultiplyColorByRGBAOffscreen(
-    offscreenIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a = 1.0
-  ) {
-    this._userOffscreenMultiplyColors[offscreenIndex].color.r = r;
-    this._userOffscreenMultiplyColors[offscreenIndex].color.g = g;
-    this._userOffscreenMultiplyColors[offscreenIndex].color.b = b;
-    this._userOffscreenMultiplyColors[offscreenIndex].color.a = a;
-  }
-
-  /**
-   * Offscreenのスクリーン色をセットする
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   * @param color 設定するスクリーン色(CubismTextureColor)
-   */
-  public setScreenColorByTextureColorOffscreen(
-    offscreenIndex: number,
-    color: CubismTextureColor
-  ) {
-    this.setScreenColorByRGBAOffscreen(
-      offscreenIndex,
-      color.r,
-      color.g,
-      color.b,
-      color.a
-    );
-  }
-
-  /**
-   * Offscreenのスクリーン色をセットする
-   *
-   * @param offscreenIndex Offscreenのインデックス
-   * @param r 設定するスクリーン色のR値
-   * @param g 設定するスクリーン色のG値
-   * @param b 設定するスクリーン色のB値
-   * @param a 設定するスクリーン色のA値
-   */
-  public setScreenColorByRGBAOffscreen(
-    offscreenIndex: number,
-    r: number,
-    g: number,
-    b: number,
-    a = 1.0
-  ) {
-    this._userOffscreenScreenColors[offscreenIndex].color.r = r;
-    this._userOffscreenScreenColors[offscreenIndex].color.g = g;
-    this._userOffscreenScreenColors[offscreenIndex].color.b = b;
-    this._userOffscreenScreenColors[offscreenIndex].color.a = a;
+  public getOverrideMultiplyAndScreenColor(): CubismModelMultiplyAndScreenColor {
+    return this._overrideMultiplyAndScreenColor;
   }
 
   /**
@@ -759,489 +331,6 @@ export class CubismModel {
   }
 
   /**
-   * SDKから指定したモデルの乗算色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForModelMultiplyColors() に置き換え
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverwriteFlagForModelMultiplyColors(): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForModelMultiplyColors() is a deprecated function. Please use getOverrideFlagForModelMultiplyColors().'
-    );
-    return this.getOverrideFlagForModelMultiplyColors();
-  }
-
-  /**
-   * SDKから指定したモデルの乗算色を上書きするか
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForModelMultiplyColors(): boolean {
-    return this._isOverriddenModelMultiplyColors;
-  }
-
-  /**
-   * SDKから指定したモデルのスクリーン色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForModelScreenColors() に置き換え
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverwriteFlagForModelScreenColors(): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForModelScreenColors() is a deprecated function. Please use getOverrideFlagForModelScreenColors().'
-    );
-    return this.getOverrideFlagForModelScreenColors();
-  }
-
-  /**
-   * SDKから指定したモデルのスクリーン色を上書きするか
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForModelScreenColors(): boolean {
-    return this._isOverriddenModelScreenColors;
-  }
-
-  /**
-   * SDKから指定したモデルの乗算色を上書きするかセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForModelMultiplyColors(value: boolean) に置き換え
-   *
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteFlagForModelMultiplyColors(value: boolean) {
-    CubismLogWarning(
-      'setOverwriteFlagForModelMultiplyColors(value: boolean) is a deprecated function. Please use setOverrideFlagForModelMultiplyColors(value: boolean).'
-    );
-    this.setOverrideFlagForModelMultiplyColors(value);
-  }
-
-  /**
-   * SDKから指定したモデルの乗算色を上書きするかセットする
-   *
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForModelMultiplyColors(value: boolean) {
-    this._isOverriddenModelMultiplyColors = value;
-  }
-
-  /**
-   * SDKから指定したモデルのスクリーン色を上書きするかセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForModelScreenColors(value: boolean) に置き換え
-   *
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteFlagForModelScreenColors(value: boolean) {
-    CubismLogWarning(
-      'setOverwriteFlagForModelScreenColors(value: boolean) is a deprecated function. Please use setOverrideFlagForModelScreenColors(value: boolean).'
-    );
-    this.setOverrideFlagForModelScreenColors(value);
-  }
-
-  /**
-   * SDKから指定したモデルのスクリーン色を上書きするかセットする
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForModelScreenColors(value: boolean) {
-    this._isOverriddenModelScreenColors = value;
-  }
-
-  /**
-   * SDKから指定したDrawableIndexの乗算色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForDrawableMultiplyColors(drawableIndex: number) に置き換え
-   *
-   * @param drawableIndex drawableのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverwriteFlagForDrawableMultiplyColors(
-    drawableIndex: number
-  ): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForDrawableMultiplyColors(drawableIndex: number) is a deprecated function. Please use getOverrideFlagForDrawableMultiplyColors(drawableIndex: number).'
-    );
-    return this.getOverrideFlagForDrawableMultiplyColors(drawableIndex);
-  }
-
-  /**
-   * SDKから指定したDrawableIndexの乗算色を上書きするか
-   *
-   * @param drawableIndex drawableのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForDrawableMultiplyColors(
-    drawableIndex: number
-  ): boolean {
-    return this._userDrawableMultiplyColors[drawableIndex].isOverridden;
-  }
-
-  /**
-   * SDKから指定したDrawableIndexのスクリーン色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForDrawableScreenColors(drawableIndex: number) に置き換え
-   *
-   * @param drawableIndex drawableのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverwriteFlagForDrawableScreenColors(
-    drawableIndex: number
-  ): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForDrawableScreenColors(drawableIndex: number) is a deprecated function. Please use getOverrideFlagForDrawableScreenColors(drawableIndex: number).'
-    );
-    return this.getOverrideFlagForDrawableScreenColors(drawableIndex);
-  }
-
-  /**
-   * SDKから指定したDrawableIndexのスクリーン色を上書きするか
-   *
-   * @param drawableIndex drawableのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForDrawableScreenColors(
-    drawableIndex: number
-  ): boolean {
-    return this._userDrawableScreenColors[drawableIndex].isOverridden;
-  }
-
-  /**
-   * SDKから指定したDrawableIndexの乗算色を上書きするかセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForDrawableMultiplyColors(drawableIndex: number, value: boolean) に置き換え
-   *
-   * @param drawableIndex drawableのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteFlagForDrawableMultiplyColors(
-    drawableIndex: number,
-    value: boolean
-  ) {
-    CubismLogWarning(
-      'setOverwriteFlagForDrawableMultiplyColors(drawableIndex: number, value: boolean) is a deprecated function. Please use setOverrideFlagForDrawableMultiplyColors(drawableIndex: number, value: boolean).'
-    );
-    this.setOverrideFlagForDrawableMultiplyColors(drawableIndex, value);
-  }
-
-  /**
-   * SDKから指定したDrawableIndexの乗算色を上書きするかセットする
-   *
-   * @param drawableIndex drawableのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForDrawableMultiplyColors(
-    drawableIndex: number,
-    value: boolean
-  ) {
-    this._userDrawableMultiplyColors[drawableIndex].isOverridden = value;
-  }
-
-  /**
-   * SDKから指定したDrawableIndexのスクリーン色を上書きするかセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForDrawableScreenColors(drawableIndex: number, value: boolean) に置き換え
-   *
-   * @param drawableIndex drawableのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteFlagForDrawableScreenColors(
-    drawableIndex: number,
-    value: boolean
-  ) {
-    CubismLogWarning(
-      'setOverwriteFlagForDrawableScreenColors(drawableIndex: number, value: boolean) is a deprecated function. Please use setOverrideFlagForDrawableScreenColors(drawableIndex: number, value: boolean).'
-    );
-    this.setOverrideFlagForDrawableScreenColors(drawableIndex, value);
-  }
-
-  /**
-   * SDKから指定したDrawableIndexのスクリーン色を上書きするかセットする
-   *
-   * @param drawableIndex drawableのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForDrawableScreenColors(
-    drawableIndex: number,
-    value: boolean
-  ) {
-    this._userDrawableScreenColors[drawableIndex].isOverridden = value;
-  }
-
-  /**
-   * SDKからpartの乗算色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideColorForPartMultiplyColors(partIndex: number) に置き換え
-   *
-   * @param partIndex partのインデックス
-   *
-   * @return true    ->  SDKからの情報を優先する
-   *          false   ->  モデルに設定されている色情報を使用
-   */
-  public getOverwriteColorForPartMultiplyColors(partIndex: number) {
-    CubismLogWarning(
-      'getOverwriteColorForPartMultiplyColors(partIndex: number) is a deprecated function. Please use getOverrideColorForPartMultiplyColors(partIndex: number).'
-    );
-    return this.getOverrideColorForPartMultiplyColors(partIndex);
-  }
-
-  /**
-   * SDKからpartの乗算色を上書きするか
-   *
-   * @param partIndex partのインデックス
-   *
-   * @return true    ->  SDKからの情報を優先する
-   *          false   ->  モデルに設定されている色情報を使用
-   */
-  public getOverrideColorForPartMultiplyColors(partIndex: number) {
-    return this._userPartMultiplyColors[partIndex].isOverridden;
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするか
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideColorForPartScreenColors(partIndex: number) に置き換え
-   *
-   * @param partIndex partのインデックス
-   *
-   * @return true    ->  SDKからの情報を優先する
-   *          false   ->  モデルに設定されている色情報を使用
-   */
-  public getOverwriteColorForPartScreenColors(partIndex: number) {
-    CubismLogWarning(
-      'getOverwriteColorForPartScreenColors(partIndex: number) is a deprecated function. Please use getOverrideColorForPartScreenColors(partIndex: number).'
-    );
-    return this.getOverrideColorForPartScreenColors(partIndex);
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするか
-   *
-   * @param partIndex partのインデックス
-   *
-   * @return true    ->  SDKからの情報を優先する
-   *          false   ->  モデルに設定されている色情報を使用
-   */
-  public getOverrideColorForPartScreenColors(partIndex: number) {
-    return this._userPartScreenColors[partIndex].isOverridden;
-  }
-
-  /**
-   * partのOverrideFlag setter関数
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideColorForPartColors(
-   * partIndex: number,
-   * value: boolean,
-   * partColors: Array<PartColorData>,
-   * drawableColors: Array<DrawableColorData>) に置き換え
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   * @param partColors 設定するpartのカラーデータ配列
-   * @param drawableColors partに関連するDrawableのカラーデータ配列
-   */
-  public setOverwriteColorForPartColors(
-    partIndex: number,
-    value: boolean,
-    partColors: Array<PartColorData>,
-    drawableColors: Array<DrawableColorData>
-  ) {
-    CubismLogWarning(
-      'setOverwriteColorForPartColors(partIndex: number, value: boolean, partColors: Array<PartColorData>, drawableColors: Array<DrawableColorData>) is a deprecated function. Please use setOverrideColorForPartColors(partIndex: number, value: boolean, partColors: Array<PartColorData>, drawableColors: Array<DrawableColorData>).'
-    );
-    this.setOverrideColorForPartColors(
-      partIndex,
-      value,
-      partColors,
-      drawableColors
-    );
-  }
-
-  /**
-   * partのOverrideFlag setter関数
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   * @param partColors 設定するpartのカラーデータ配列
-   * @param drawableColors partに関連するDrawableのカラーデータ配列
-   */
-  public setOverrideColorForPartColors(
-    partIndex: number,
-    value: boolean,
-    partColors: Array<ColorData>,
-    drawableColors: Array<ColorData>
-  ) {
-    partColors[partIndex].isOverridden = value;
-
-    for (let i = 0; i < this._partChildDrawables[partIndex].length; ++i) {
-      const drawableIndex = this._partChildDrawables[partIndex][i];
-      drawableColors[drawableIndex].isOverridden = value;
-
-      if (value) {
-        drawableColors[drawableIndex].color.r = partColors[partIndex].color.r;
-        drawableColors[drawableIndex].color.g = partColors[partIndex].color.g;
-        drawableColors[drawableIndex].color.b = partColors[partIndex].color.b;
-        drawableColors[drawableIndex].color.a = partColors[partIndex].color.a;
-      }
-    }
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするかをセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideColorForPartMultiplyColors(partIndex: number, value: boolean) に置き換え
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteColorForPartMultiplyColors(
-    partIndex: number,
-    value: boolean
-  ) {
-    CubismLogWarning(
-      'setOverwriteColorForPartMultiplyColors(partIndex: number, value: boolean) is a deprecated function. Please use setOverrideColorForPartMultiplyColors(partIndex: number, value: boolean).'
-    );
-    this.setOverrideColorForPartMultiplyColors(partIndex, value);
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするかをセットする
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideColorForPartMultiplyColors(
-    partIndex: number,
-    value: boolean
-  ) {
-    this._userPartMultiplyColors[partIndex].isOverridden = value;
-    this.setOverrideColorForPartColors(
-      partIndex,
-      value,
-      this._userPartMultiplyColors,
-      this._userDrawableMultiplyColors
-    );
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするかをセットする
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideColorForPartScreenColors(partIndex: number, value: boolean) に置き換え
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverwriteColorForPartScreenColors(
-    partIndex: number,
-    value: boolean
-  ) {
-    CubismLogWarning(
-      'setOverwriteColorForPartScreenColors(partIndex: number, value: boolean) is a deprecated function. Please use setOverrideColorForPartScreenColors(partIndex: number, value: boolean).'
-    );
-    this.setOverrideColorForPartScreenColors(partIndex, value);
-  }
-
-  /**
-   * SDKからpartのスクリーン色を上書きするかをセットする
-   *
-   * @param partIndex partのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideColorForPartScreenColors(
-    partIndex: number,
-    value: boolean
-  ) {
-    this._userPartScreenColors[partIndex].isOverridden = value;
-    this.setOverrideColorForPartColors(
-      partIndex,
-      value,
-      this._userPartScreenColors,
-      this._userDrawableScreenColors
-    );
-  }
-
-  /**
-   * SDKから指定したOffscreenIndexの乗算色を上書きするか
-   *
-   * @param offscreenIndex offscreenのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForOffscreenMultiplyColors(
-    offscreenIndex: number
-  ): boolean {
-    return this._userOffscreenMultiplyColors[offscreenIndex].isOverridden;
-  }
-
-  /**
-   * SDKから指定したOffscreenIndexのスクリーン色を上書きするか
-   *
-   * @param offscreenIndex offscreenのインデックス
-   *
-   * @return true -> SDKからの情報を優先する
-   *          false -> モデルに設定されている色情報を使用
-   */
-  public getOverrideFlagForOffscreenScreenColors(
-    offscreemIndex: number
-  ): boolean {
-    return this._userOffscreenScreenColors[offscreemIndex].isOverridden;
-  }
-
-  /**
-   * SDKから指定したDrawableIndexの乗算色を上書きするかセットする
-   *
-   * @param offscreenIndex offscreenのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForOffscreenMultiplyColors(
-    offscreenIndex: number,
-    value: boolean
-  ) {
-    this._userOffscreenMultiplyColors[offscreenIndex].isOverridden = value;
-  }
-
-  /**
-   * SDKから指定したOffscreenIndexのスクリーン色を上書きするかセットする
-   *
-   * @param offscreenIndex offscreenのインデックス
-   * @param value true -> SDKからの情報を優先する
-   *              false -> モデルに設定されている色情報を使用
-   */
-  public setOverrideFlagForOffscreenScreenColors(
-    offscreenIndex: number,
-    value: boolean
-  ) {
-    this._userOffscreenScreenColors[offscreenIndex].isOverridden = value;
-  }
-
-  /**
    * Drawableのカリング情報を取得する。
    *
    * @param   drawableIndex   Drawableのインデックス
@@ -1306,21 +395,6 @@ export class CubismModel {
   /**
    * SDKからモデル全体のカリング設定を上書きするか。
    *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForModelCullings() に置き換え
-   *
-   * @return  true    ->  SDK上のカリング設定を使用
-   *          false   ->  モデルのカリング設定を使用
-   */
-  public getOverwriteFlagForModelCullings(): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForModelCullings() is a deprecated function. Please use getOverrideFlagForModelCullings().'
-    );
-    return this.getOverrideFlagForModelCullings();
-  }
-
-  /**
-   * SDKからモデル全体のカリング設定を上書きするか。
-   *
    * @return  true    ->  SDK上のカリング設定を使用
    *          false   ->  モデルのカリング設定を使用
    */
@@ -1331,39 +405,10 @@ export class CubismModel {
   /**
    * SDKからモデル全体のカリング設定を上書きするかを設定する。
    *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForModelCullings(isOverriddenCullings: boolean) に置き換え
-   *
-   * @param isOveriddenCullings SDK上のカリング設定を使うならtrue、モデルのカリング設定を使うならfalse
-   */
-  public setOverwriteFlagForModelCullings(isOverriddenCullings: boolean): void {
-    CubismLogWarning(
-      'setOverwriteFlagForModelCullings(isOverriddenCullings: boolean) is a deprecated function. Please use setOverrideFlagForModelCullings(isOverriddenCullings: boolean).'
-    );
-    this.setOverrideFlagForModelCullings(isOverriddenCullings);
-  }
-
-  /**
-   * SDKからモデル全体のカリング設定を上書きするかを設定する。
-   *
    * @param isOverriddenCullings SDK上のカリング設定を使うならtrue、モデルのカリング設定を使うならfalse
    */
   public setOverrideFlagForModelCullings(isOverriddenCullings: boolean): void {
     this._isOverriddenCullings = isOverriddenCullings;
-  }
-
-  /**
-   *
-   * @deprecated 名称変更のため非推奨 getOverrideFlagForDrawableCullings(drawableIndex: number) に置き換え
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @return  true    ->  SDK上のカリング設定を使用
-   *          false   ->  モデルのカリング設定を使用
-   */
-  public getOverwriteFlagForDrawableCullings(drawableIndex: number): boolean {
-    CubismLogWarning(
-      'getOverwriteFlagForDrawableCullings(drawableIndex: number) is a deprecated function. Please use getOverrideFlagForDrawableCullings(drawableIndex: number).'
-    );
-    return this.getOverrideFlagForDrawableCullings(drawableIndex);
   }
 
   /**
@@ -1383,26 +428,6 @@ export class CubismModel {
    */
   public getOverrideFlagForOffscreenCullings(offscreenIndex: number): boolean {
     return this._userOffscreenCullings[offscreenIndex].isOverridden;
-  }
-
-  /**
-   *
-   * @deprecated 名称変更のため非推奨 setOverrideFlagForDrawableCullings(drawableIndex: number, isOverriddenCullings: bolean) に置き換え
-   *
-   * @param drawableIndex Drawableのインデックス
-   * @param isOverriddenCullings SDK上のカリング設定を使うならtrue、モデルのカリング設定を使うならfalse
-   */
-  public setOverwriteFlagForDrawableCullings(
-    drawableIndex: number,
-    isOverriddenCullings: boolean
-  ): void {
-    CubismLogWarning(
-      'setOverwriteFlagForDrawableCullings(drawableIndex: number, isOverriddenCullings: boolean) is a deprecated function. Please use setOverrideFlagForDrawableCullings(drawableIndex: number, isOverriddenCullings: boolean).'
-    );
-    this.setOverrideFlagForDrawableCullings(
-      drawableIndex,
-      isOverriddenCullings
-    );
   }
 
   /**
@@ -1489,6 +514,16 @@ export class CubismModel {
   public getPartCount(): number {
     const partCount: number = this._model.parts.count;
     return partCount;
+  }
+
+  /**
+   * パーツのオフスクリーンインデックスの取得
+   * @param partIndex パーツのインデックス
+   * @return オフスクリーンインデックスのリスト
+   */
+  public getPartOffscreenIndices(): Int32Array {
+    const offscreenIndices = this._model.parts.offscreenIndices;
+    return offscreenIndices;
   }
 
   /**
@@ -1975,18 +1010,6 @@ export class CubismModel {
   public getRenderOrders(): Int32Array {
     const renderOrders: Int32Array = this._model.getRenderOrders();
     return renderOrders;
-  }
-
-  /**
-   * @deprecated
-   * 関数名が誤っていたため、代替となる getDrawableTextureIndex を追加し、この関数は非推奨となりました。
-   *
-   * Drawableのテクスチャインデックスリストの取得
-   * @param drawableIndex Drawableのインデックス
-   * @return drawableのテクスチャインデックスリスト
-   */
-  public getDrawableTextureIndices(drawableIndex: number): number {
-    return this.getDrawableTextureIndex(drawableIndex);
   }
 
   /**
@@ -2554,87 +1577,29 @@ export class CubismModel {
       const drawableIds: string[] = this._model.drawables.ids;
       const drawableCount: number = this._model.drawables.count;
 
-      const offsetsPartChildDrawables: number[] = new Array<number>();
-
-      offsetsPartChildDrawables.length = partCount;
-      this._userPartMultiplyColors.length = partCount;
-      this._userPartScreenColors.length = partCount;
-      this._partChildDrawables.length = partCount;
-
-      this._userDrawableMultiplyColors.length = drawableCount;
-      this._userDrawableScreenColors.length = drawableCount;
-
-      // カリング設定
+      // Drawableカリング設定
       this._userDrawableCullings.length = drawableCount;
       const userCulling: CullingData = new CullingData(false, false);
 
-      // Part
-      {
-        for (let i = 0; i < partCount; ++i) {
-          const multiplyColor: CubismTextureColor = new CubismTextureColor(
-            1.0,
-            1.0,
-            1.0,
-            1.0
-          );
-          const screenColor: CubismTextureColor = new CubismTextureColor(
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          );
-
-          const userMultiplyColor: PartColorData = new PartColorData(
-            false,
-            multiplyColor
-          );
-          const userScreenColor: PartColorData = new PartColorData(
-            false,
-            screenColor
-          );
-
-          this._userPartMultiplyColors[i] = userMultiplyColor;
-          this._userPartScreenColors[i] = userScreenColor;
-          this._partChildDrawables[i] = new Array<number>();
-          this._partChildDrawables[i].length = drawableCount;
-        }
-      }
+      // Offscreenカリング設定
+      this._userOffscreenCullings.length = this._model.offscreens.count;
+      const userOffscreenCulling: CullingData = new CullingData(false, false);
 
       // Drawables
       {
         for (let i = 0; i < drawableCount; ++i) {
-          const multiplyColor: CubismTextureColor = new CubismTextureColor(
-            1.0,
-            1.0,
-            1.0,
-            1.0
-          );
-          const screenColor: CubismTextureColor = new CubismTextureColor(
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          );
-
-          const userMultiplyColor: ColorData = new ColorData(
-            false,
-            multiplyColor
-          );
-          const userScreenColor: ColorData = new ColorData(false, screenColor);
-
           this._drawableIds.push(
             CubismFramework.getIdManager().getId(drawableIds[i])
           );
 
-          this._userDrawableMultiplyColors[i] = userMultiplyColor;
-          this._userDrawableScreenColors[i] = userScreenColor;
-
           this._userDrawableCullings[i] = userCulling;
+        }
+      }
 
-          const parentIndex = this.getDrawableParentPartIndex(i);
-          if (parentIndex >= 0) {
-            this._partChildDrawables[parentIndex][i] = i;
-          }
+      // Offscreens
+      {
+        for (let i = 0; i < this._model.offscreens.count; ++i) {
+          this._userOffscreenCullings[i] = userOffscreenCulling;
         }
       }
 
@@ -2663,48 +1628,15 @@ export class CubismModel {
         }
       }
 
-      // Offscreen
-      {
-        // オフスクリーンの初期化
-        const offscreenCount: number = this._model.offscreens.count;
-
-        this._userOffscreenMultiplyColors = new Array<ColorData>();
-        this._userOffscreenScreenColors = new Array<ColorData>();
-        this._userOffscreenCullings = new Array<CullingData>();
-
-        // 乗算色・スクリーン色・カリング・オフスクリーン情報の配列を用意
-        this._userOffscreenMultiplyColors.length = offscreenCount;
-        this._userOffscreenScreenColors.length = offscreenCount;
-        this._userOffscreenCullings.length = offscreenCount;
-
-        for (let i = 0; i < offscreenCount; ++i) {
-          const multiplyColor: CubismTextureColor = new CubismTextureColor(
-            1.0,
-            1.0,
-            1.0,
-            1.0
-          );
-          const screenColor: CubismTextureColor = new CubismTextureColor(
-            0.0,
-            0.0,
-            0.0,
-            1.0
-          );
-
-          // 乗算色
-          const userMultiplyColor: ColorData = new ColorData(
-            false,
-            multiplyColor
-          );
-          // スクリーン色
-          const userScreenColor: ColorData = new ColorData(false, screenColor);
-
-          this._userOffscreenMultiplyColors[i] = userMultiplyColor;
-          this._userOffscreenScreenColors[i] = userScreenColor;
-          this._userOffscreenCullings[i] = userCulling;
-        }
-      }
       this.setupPartsHierarchy();
+
+      // CubismModelMultiplyAndScreenColorの初期化
+      const offscreenCount = this.getOffscreenCount();
+      this._overrideMultiplyAndScreenColor.initialize(
+        partCount,
+        drawableCount,
+        offscreenCount
+      );
     }
   }
 
@@ -2874,10 +1806,12 @@ export class CubismModel {
     this._drawableIds = new Array<CubismIdHandle>();
     this._partIds = new Array<CubismIdHandle>();
     this._isOverriddenParameterRepeat = true;
-    this._isOverriddenModelMultiplyColors = false;
-    this._isOverriddenModelScreenColors = false;
     this._isOverriddenCullings = false;
     this._modelOpacity = 1.0;
+
+    // CubismModelMultiplyAndScreenColorのインスタンスを作成
+    this._overrideMultiplyAndScreenColor =
+      new CubismModelMultiplyAndScreenColor(this);
 
     this._isBlendModeEnabled = false;
     this._drawableColorBlends = null;
@@ -2890,12 +1824,8 @@ export class CubismModel {
     this._offscreenScreenColors = null;
 
     this._userParameterRepeatDataList = new Array<ParameterRepeatData>();
-    this._userDrawableMultiplyColors = new Array<ColorData>();
-    this._userDrawableScreenColors = new Array<ColorData>();
     this._userDrawableCullings = new Array<CullingData>();
-    this._userPartMultiplyColors = new Array<ColorData>();
-    this._userPartScreenColors = new Array<ColorData>();
-    this._partChildDrawables = new Array<Array<number>>();
+    this._userOffscreenCullings = new Array<CullingData>();
     this._partsHierarchy = new Array<CubismModelPartInfo>();
 
     this._notExistPartId = new Map<CubismIdHandle, number>();
@@ -2951,21 +1881,12 @@ export class CubismModel {
    */
   private _isOverriddenParameterRepeat: boolean;
 
-  private _isOverriddenModelMultiplyColors: boolean; // SDK上でモデル全体の乗算色を上書きするか判定するフラグ
-  private _isOverriddenModelScreenColors: boolean; // SDK上でモデル全体のスクリーン色を上書きするか判定するフラグ
+  private _overrideMultiplyAndScreenColor: CubismModelMultiplyAndScreenColor; // 乗算色・スクリーン色の管理クラス
 
   /**
    * List to manage ParameterRepeat and Override flag to be set for each Parameter
    */
   private _userParameterRepeatDataList: Array<ParameterRepeatData>;
-
-  private _userDrawableMultiplyColors: Array<ColorData>; // Drawableごとに設定する乗算色と上書きフラグを管理するリスト
-  private _userDrawableScreenColors: Array<ColorData>; // Drawableごとに設定するスクリーン色と上書きフラグを管理するリスト
-  private _userPartScreenColors: Array<ColorData>; // Part 乗算色の配列
-  private _userPartMultiplyColors: Array<ColorData>; // Part スクリーン色の配列
-  private _userOffscreenMultiplyColors: Array<ColorData>; // Offscreen 乗算色の配列
-  private _userOffscreenScreenColors: Array<ColorData>; // Off
-  private _partChildDrawables: Array<Array<number>>; // Partの子DrawableIndexの配列
   private _partsHierarchy: Array<CubismModelPartInfo>; // Partの親子構造
 
   private _model: Live2DCubismCore.Model; // モデル

--- a/src/model/cubismmodelmultiplyandscreencolor.ts
+++ b/src/model/cubismmodelmultiplyandscreencolor.ts
@@ -1,0 +1,1066 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { CubismTextureColor } from '../rendering/cubismrenderer';
+import { CubismModelObjectType, NoOffscreenIndex } from './cubismmodel';
+import { CubismLogWarning } from '../utils/cubismdebug';
+
+/**
+ * SDK側から与えられた描画オブジェクトの乗算色・スクリーン色上書きフラグと
+ * その色を保持する構造体
+ */
+export class ColorData {
+  constructor(
+    isOverridden = false,
+    color: CubismTextureColor = new CubismTextureColor()
+  ) {
+    this.isOverridden = isOverridden;
+    this.color = color;
+  }
+
+  public isOverridden: boolean;
+  public color: CubismTextureColor;
+}
+
+/**
+ * Handling multiply and screen colors of the model.
+ */
+export class CubismModelMultiplyAndScreenColor {
+  private _model: any; // CubismModel
+  private _isOverriddenModelMultiplyColors: boolean;
+  private _isOverriddenModelScreenColors: boolean;
+  private _userPartScreenColors: Array<ColorData>;
+  private _userPartMultiplyColors: Array<ColorData>;
+  private _userDrawableScreenColors: Array<ColorData>;
+  private _userDrawableMultiplyColors: Array<ColorData>;
+  private _userOffscreenScreenColors: Array<ColorData>;
+  private _userOffscreenMultiplyColors: Array<ColorData>;
+
+  /**
+   * Constructor.
+   *
+   * @param model cubism model.
+   */
+  public constructor(model: any) {
+    this._model = model;
+    this._isOverriddenModelMultiplyColors = false;
+    this._isOverriddenModelScreenColors = false;
+    this._userPartScreenColors = [];
+    this._userPartMultiplyColors = [];
+    this._userDrawableScreenColors = [];
+    this._userDrawableMultiplyColors = [];
+    this._userOffscreenScreenColors = [];
+    this._userOffscreenMultiplyColors = [];
+  }
+
+  /**
+   * Initialization for using multiply and screen colors.
+   *
+   * @param partCount number of parts.
+   * @param drawableCount number of drawables.
+   * @param offscreenCount number of offscreen.
+   */
+  public initialize(
+    partCount: number,
+    drawableCount: number,
+    offscreenCount: number
+  ): void {
+    // 乗算色の初期値
+    const userMultiplyColor = new ColorData(
+      false,
+      new CubismTextureColor(1.0, 1.0, 1.0, 1.0)
+    );
+
+    // スクリーン色の初期値
+    const userScreenColor = new ColorData(
+      false,
+      new CubismTextureColor(0.0, 0.0, 0.0, 1.0)
+    );
+
+    // Part
+    this._userPartMultiplyColors = new Array(partCount);
+    this._userPartScreenColors = new Array(partCount);
+    for (let i = 0; i < partCount; i++) {
+      this._userPartMultiplyColors[i] = new ColorData(
+        userMultiplyColor.isOverridden,
+        new CubismTextureColor(
+          userMultiplyColor.color.r,
+          userMultiplyColor.color.g,
+          userMultiplyColor.color.b,
+          userMultiplyColor.color.a
+        )
+      );
+      this._userPartScreenColors[i] = new ColorData(
+        userScreenColor.isOverridden,
+        new CubismTextureColor(
+          userScreenColor.color.r,
+          userScreenColor.color.g,
+          userScreenColor.color.b,
+          userScreenColor.color.a
+        )
+      );
+    }
+
+    // Drawable
+    this._userDrawableMultiplyColors = new Array(drawableCount);
+    this._userDrawableScreenColors = new Array(drawableCount);
+    for (let i = 0; i < drawableCount; i++) {
+      this._userDrawableMultiplyColors[i] = new ColorData(
+        userMultiplyColor.isOverridden,
+        new CubismTextureColor(
+          userMultiplyColor.color.r,
+          userMultiplyColor.color.g,
+          userMultiplyColor.color.b,
+          userMultiplyColor.color.a
+        )
+      );
+      this._userDrawableScreenColors[i] = new ColorData(
+        userScreenColor.isOverridden,
+        new CubismTextureColor(
+          userScreenColor.color.r,
+          userScreenColor.color.g,
+          userScreenColor.color.b,
+          userScreenColor.color.a
+        )
+      );
+    }
+
+    // Offscreen
+    this._userOffscreenMultiplyColors = new Array(offscreenCount);
+    this._userOffscreenScreenColors = new Array(offscreenCount);
+    for (let i = 0; i < offscreenCount; i++) {
+      this._userOffscreenMultiplyColors[i] = new ColorData(
+        userMultiplyColor.isOverridden,
+        new CubismTextureColor(
+          userMultiplyColor.color.r,
+          userMultiplyColor.color.g,
+          userMultiplyColor.color.b,
+          userMultiplyColor.color.a
+        )
+      );
+      this._userOffscreenScreenColors[i] = new ColorData(
+        userScreenColor.isOverridden,
+        new CubismTextureColor(
+          userScreenColor.color.r,
+          userScreenColor.color.g,
+          userScreenColor.color.b,
+          userScreenColor.color.a
+        )
+      );
+    }
+  }
+
+  /**
+   * Outputs a warning message for index out of range errors.
+   *
+   * @param functionName Name of the calling function
+   * @param index The invalid index value
+   * @param maxIndex The maximum valid index (length - 1)
+   */
+  private warnIndexOutOfRange(
+    functionName: string,
+    index: number,
+    maxIndex: number
+  ): void {
+    CubismLogWarning(
+      `${functionName}: index is out of range. index=${index}, valid range=[0, ${maxIndex}].`
+    );
+  }
+
+  /**
+   * Validates if the given part index is within valid range.
+   *
+   * @param index Part index to validate
+   * @param functionName Name of the calling function for error reporting
+   * @return true if the index is valid; otherwise false
+   */
+  private isValidPartIndex(index: number, functionName: string): boolean {
+    if (index < 0 || index >= this._model.getPartCount()) {
+      this.warnIndexOutOfRange(
+        functionName,
+        index,
+        this._model.getPartCount() - 1
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Validates if the given drawable index is within valid range.
+   *
+   * @param index Drawable index to validate
+   * @param functionName Name of the calling function for error reporting
+   * @return true if the index is valid; otherwise false
+   */
+  private isValidDrawableIndex(index: number, functionName: string): boolean {
+    if (index < 0 || index >= this._model.getDrawableCount()) {
+      this.warnIndexOutOfRange(
+        functionName,
+        index,
+        this._model.getDrawableCount() - 1
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Validates if the given offscreen index is within valid range.
+   *
+   * @param index Offscreen index to validate
+   * @param functionName Name of the calling function for error reporting
+   * @return true if the index is valid; otherwise false
+   */
+  private isValidOffscreenIndex(index: number, functionName: string): boolean {
+    if (index < 0 || index >= this._model.getOffscreenCount()) {
+      this.warnIndexOutOfRange(
+        functionName,
+        index,
+        this._model.getOffscreenCount() - 1
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Sets the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+   *
+   * @param value true if the color set at runtime is to be used; otherwise false.
+   */
+  public setMultiplyColorEnabled(value: boolean): void {
+    this._isOverriddenModelMultiplyColors = value;
+  }
+
+  /**
+   * Returns the flag indicating whether the color set at runtime is used as the multiply color for the entire model during rendering.
+   *
+   * @return true if the color set at runtime is used; otherwise false.
+   */
+  public getMultiplyColorEnabled(): boolean {
+    return this._isOverriddenModelMultiplyColors;
+  }
+
+  /**
+   * Sets the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+   *
+   * @param value true if the color set at runtime is to be used; otherwise false.
+   */
+  public setScreenColorEnabled(value: boolean): void {
+    this._isOverriddenModelScreenColors = value;
+  }
+
+  /**
+   * Returns the flag indicating whether the color set at runtime is used as the screen color for the entire model during rendering.
+   *
+   * @return true if the color set at runtime is used; otherwise false.
+   */
+  public getScreenColorEnabled(): boolean {
+    return this._isOverriddenModelScreenColors;
+  }
+
+  /**
+   * Sets whether the part multiply color is overridden by the SDK.
+   * Use true to use the color information from the SDK, or false to use the color information from the model.
+   *
+   * @param partIndex Part index
+   * @param value true enable override, false to disable
+   */
+  public setPartMultiplyColorEnabled(partIndex: number, value: boolean): void {
+    if (!this.isValidPartIndex(partIndex, 'setPartMultiplyColorEnabled')) {
+      return;
+    }
+    this.setPartColorEnabled(
+      partIndex,
+      value,
+      this._userPartMultiplyColors,
+      this._userDrawableMultiplyColors,
+      this._userOffscreenMultiplyColors
+    );
+  }
+
+  /**
+   * Checks whether the part multiply color is overridden by the SDK.
+   *
+   * @param partIndex Part index
+   *
+   * @return true if the color information from the SDK is used; otherwise false.
+   */
+  public getPartMultiplyColorEnabled(partIndex: number): boolean {
+    if (!this.isValidPartIndex(partIndex, 'getPartMultiplyColorEnabled')) {
+      return false;
+    }
+    return this._userPartMultiplyColors[partIndex].isOverridden;
+  }
+
+  /**
+   * Sets whether the part screen color is overridden by the SDK.
+   * Use true to use the color information from the SDK, or false to use the color information from the model.
+   *
+   * @param partIndex Part index
+   * @param value true enable override, false to disable
+   */
+  public setPartScreenColorEnabled(partIndex: number, value: boolean): void {
+    if (!this.isValidPartIndex(partIndex, 'setPartScreenColorEnabled')) {
+      return;
+    }
+    this.setPartColorEnabled(
+      partIndex,
+      value,
+      this._userPartScreenColors,
+      this._userDrawableScreenColors,
+      this._userOffscreenScreenColors
+    );
+  }
+
+  /**
+   * Checks whether the part screen color is overridden by the SDK.
+   *
+   * @param partIndex Part index
+   *
+   * @return true if the color information from the SDK is used; otherwise false.
+   */
+  public getPartScreenColorEnabled(partIndex: number): boolean {
+    if (!this.isValidPartIndex(partIndex, 'getPartScreenColorEnabled')) {
+      return false;
+    }
+    return this._userPartScreenColors[partIndex].isOverridden;
+  }
+
+  /**
+   * Sets the multiply color of the part.
+   *
+   * @param partIndex Part index
+   * @param color Multiply color to be set (CubismTextureColor)
+   */
+  public setPartMultiplyColorByTextureColor(
+    partIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (
+      !this.isValidPartIndex(partIndex, 'setPartMultiplyColorByTextureColor')
+    ) {
+      return;
+    }
+    this.setPartMultiplyColorByRGBA(
+      partIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the multiply color of the part.
+   *
+   * @param partIndex Part index
+   * @param r Red value of the multiply color to be set
+   * @param g Green value of the multiply color to be set
+   * @param b Blue value of the multiply color to be set
+   * @param a Alpha value of the multiply color to be set
+   */
+  public setPartMultiplyColorByRGBA(
+    partIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (!this.isValidPartIndex(partIndex, 'setPartMultiplyColorByRGBA')) {
+      return;
+    }
+    this.setPartColor(
+      partIndex,
+      r,
+      g,
+      b,
+      a,
+      this._userPartMultiplyColors,
+      this._userDrawableMultiplyColors,
+      this._userOffscreenMultiplyColors
+    );
+  }
+
+  /**
+   * Returns the multiply color of the part.
+   *
+   * @param partIndex Part index
+   *
+   * @return Multiply color (CubismTextureColor)
+   */
+  public getPartMultiplyColor(partIndex: number): CubismTextureColor {
+    if (!this.isValidPartIndex(partIndex, 'getPartMultiplyColor')) {
+      return new CubismTextureColor(1.0, 1.0, 1.0, 1.0);
+    }
+    return this._userPartMultiplyColors[partIndex].color;
+  }
+
+  /**
+   * Sets the screen color of the part.
+   *
+   * @param partIndex Part index
+   * @param color Screen color to be set (CubismTextureColor)
+   */
+  public setPartScreenColorByTextureColor(
+    partIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (!this.isValidPartIndex(partIndex, 'setPartScreenColorByTextureColor')) {
+      return;
+    }
+    this.setPartScreenColorByRGBA(
+      partIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the screen color of the part.
+   *
+   * @param partIndex Part index
+   * @param r Red value of the screen color to be set
+   * @param g Green value of the screen color to be set
+   * @param b Blue value of the screen color to be set
+   * @param a Alpha value of the screen color to be set
+   */
+  public setPartScreenColorByRGBA(
+    partIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (!this.isValidPartIndex(partIndex, 'setPartScreenColorByRGBA')) {
+      return;
+    }
+    this.setPartColor(
+      partIndex,
+      r,
+      g,
+      b,
+      a,
+      this._userPartScreenColors,
+      this._userDrawableScreenColors,
+      this._userOffscreenScreenColors
+    );
+  }
+
+  /**
+   * Returns the screen color of the part.
+   *
+   * @param partIndex Part index
+   *
+   * @return Screen color (CubismTextureColor)
+   */
+  public getPartScreenColor(partIndex: number): CubismTextureColor {
+    if (!this.isValidPartIndex(partIndex, 'getPartScreenColor')) {
+      return new CubismTextureColor(0.0, 0.0, 0.0, 1.0);
+    }
+    return this._userPartScreenColors[partIndex].color;
+  }
+
+  /**
+   * Sets the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+   *
+   * @param drawableIndex Drawable index
+   * @param value true if the color set at runtime is to be used; otherwise false.
+   */
+  public setDrawableMultiplyColorEnabled(
+    drawableIndex: number,
+    value: boolean
+  ): void {
+    if (
+      !this.isValidDrawableIndex(
+        drawableIndex,
+        'setDrawableMultiplyColorEnabled'
+      )
+    ) {
+      return;
+    }
+    this._userDrawableMultiplyColors[drawableIndex].isOverridden = value;
+  }
+
+  /**
+   * Returns the flag indicating whether the color set at runtime is used as the multiply color for the drawable during rendering.
+   *
+   * @param drawableIndex Drawable index
+   *
+   * @return true if the color set at runtime is used; otherwise false.
+   */
+  public getDrawableMultiplyColorEnabled(drawableIndex: number): boolean {
+    if (
+      !this.isValidDrawableIndex(
+        drawableIndex,
+        'getDrawableMultiplyColorEnabled'
+      )
+    ) {
+      return false;
+    }
+    return this._userDrawableMultiplyColors[drawableIndex].isOverridden;
+  }
+
+  /**
+   * Sets the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+   *
+   * @param drawableIndex Drawable index
+   * @param value true if the color set at runtime is to be used; otherwise false.
+   */
+  public setDrawableScreenColorEnabled(
+    drawableIndex: number,
+    value: boolean
+  ): void {
+    if (
+      !this.isValidDrawableIndex(drawableIndex, 'setDrawableScreenColorEnabled')
+    ) {
+      return;
+    }
+    this._userDrawableScreenColors[drawableIndex].isOverridden = value;
+  }
+
+  /**
+   * Returns the flag indicating whether the color set at runtime is used as the screen color for the drawable during rendering.
+   *
+   * @param drawableIndex Drawable index
+   *
+   * @return true if the color set at runtime is used; otherwise false.
+   */
+  public getDrawableScreenColorEnabled(drawableIndex: number): boolean {
+    if (
+      !this.isValidDrawableIndex(drawableIndex, 'getDrawableScreenColorEnabled')
+    ) {
+      return false;
+    }
+    return this._userDrawableScreenColors[drawableIndex].isOverridden;
+  }
+
+  /**
+   * Sets the multiply color of the drawable.
+   *
+   * @param drawableIndex Drawable index
+   * @param color Multiply color to be set (CubismTextureColor)
+   */
+  public setDrawableMultiplyColorByTextureColor(
+    drawableIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (
+      !this.isValidDrawableIndex(
+        drawableIndex,
+        'setDrawableMultiplyColorByTextureColor'
+      )
+    ) {
+      return;
+    }
+    this.setDrawableMultiplyColorByRGBA(
+      drawableIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the multiply color of the drawable.
+   *
+   * @param drawableIndex Drawable index
+   * @param r Red value of the multiply color to be set
+   * @param g Green value of the multiply color to be set
+   * @param b Blue value of the multiply color to be set
+   * @param a Alpha value of the multiply color to be set
+   */
+  public setDrawableMultiplyColorByRGBA(
+    drawableIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (
+      !this.isValidDrawableIndex(
+        drawableIndex,
+        'setDrawableMultiplyColorByRGBA'
+      )
+    ) {
+      return;
+    }
+    this._userDrawableMultiplyColors[drawableIndex].color.r = r;
+    this._userDrawableMultiplyColors[drawableIndex].color.g = g;
+    this._userDrawableMultiplyColors[drawableIndex].color.b = b;
+    this._userDrawableMultiplyColors[drawableIndex].color.a = a;
+  }
+
+  /**
+   * Returns the multiply color from the list of drawables.
+   *
+   * @param drawableIndex Drawable index
+   *
+   * @return Multiply color (CubismTextureColor)
+   */
+  public getDrawableMultiplyColor(drawableIndex: number): CubismTextureColor {
+    if (!this.isValidDrawableIndex(drawableIndex, 'getDrawableMultiplyColor')) {
+      return new CubismTextureColor(1.0, 1.0, 1.0, 1.0);
+    }
+    if (
+      this.getMultiplyColorEnabled() ||
+      this.getDrawableMultiplyColorEnabled(drawableIndex)
+    ) {
+      return this._userDrawableMultiplyColors[drawableIndex].color;
+    }
+    return this._model.getDrawableMultiplyColor(drawableIndex);
+  }
+
+  /**
+   * Sets the screen color of the drawable.
+   *
+   * @param drawableIndex Drawable index
+   * @param color Screen color to be set (CubismTextureColor)
+   */
+  public setDrawableScreenColorByTextureColor(
+    drawableIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (
+      !this.isValidDrawableIndex(
+        drawableIndex,
+        'setDrawableScreenColorByTextureColor'
+      )
+    ) {
+      return;
+    }
+    this.setDrawableScreenColorByRGBA(
+      drawableIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the screen color of the drawable.
+   *
+   * @param drawableIndex Drawable index
+   * @param r Red value of the screen color to be set
+   * @param g Green value of the screen color to be set
+   * @param b Blue value of the screen color to be set
+   * @param a Alpha value of the screen color to be set
+   */
+  public setDrawableScreenColorByRGBA(
+    drawableIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (
+      !this.isValidDrawableIndex(drawableIndex, 'setDrawableScreenColorByRGBA')
+    ) {
+      return;
+    }
+    this._userDrawableScreenColors[drawableIndex].color.r = r;
+    this._userDrawableScreenColors[drawableIndex].color.g = g;
+    this._userDrawableScreenColors[drawableIndex].color.b = b;
+    this._userDrawableScreenColors[drawableIndex].color.a = a;
+  }
+
+  /**
+   * Returns the screen color from the list of drawables.
+   *
+   * @param drawableIndex Drawable index
+   *
+   * @return Screen color (CubismTextureColor)
+   */
+  public getDrawableScreenColor(drawableIndex: number): CubismTextureColor {
+    if (!this.isValidDrawableIndex(drawableIndex, 'getDrawableScreenColor')) {
+      return new CubismTextureColor(0.0, 0.0, 0.0, 1.0);
+    }
+    if (
+      this.getScreenColorEnabled() ||
+      this.getDrawableScreenColorEnabled(drawableIndex)
+    ) {
+      return this._userDrawableScreenColors[drawableIndex].color;
+    }
+    return this._model.getDrawableScreenColor(drawableIndex);
+  }
+
+  /**
+   * Sets whether the offscreen multiply color is overridden by the SDK.
+   * Use true to use the color information from the SDK, or false to use the color information from the model.
+   *
+   * @param offscreenIndex Offscreen index
+   * @param value true enable override, false to disable
+   */
+  public setOffscreenMultiplyColorEnabled(
+    offscreenIndex: number,
+    value: boolean
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenMultiplyColorEnabled'
+      )
+    ) {
+      return;
+    }
+    this._userOffscreenMultiplyColors[offscreenIndex].isOverridden = value;
+  }
+
+  /**
+   * Checks whether the offscreen multiply color is overridden by the SDK.
+   *
+   * @param offscreenIndex Offscreen index
+   *
+   * @return true if the color information from the SDK is used; otherwise false.
+   */
+  public getOffscreenMultiplyColorEnabled(offscreenIndex: number): boolean {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'getOffscreenMultiplyColorEnabled'
+      )
+    ) {
+      return false;
+    }
+    return this._userOffscreenMultiplyColors[offscreenIndex].isOverridden;
+  }
+
+  /**
+   * Sets whether the offscreen screen color is overridden by the SDK.
+   * Use true to use the color information from the SDK, or false to use the color information from the model.
+   *
+   * @param offscreenIndex Offscreen index
+   * @param value true enable override, false to disable
+   */
+  public setOffscreenScreenColorEnabled(
+    offscreenIndex: number,
+    value: boolean
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenScreenColorEnabled'
+      )
+    ) {
+      return;
+    }
+    this._userOffscreenScreenColors[offscreenIndex].isOverridden = value;
+  }
+
+  /**
+   * Checks whether the offscreen screen color is overridden by the SDK.
+   *
+   * @param offscreenIndex Offscreen index
+   *
+   * @return true if the color information from the SDK is used; otherwise false.
+   */
+  public getOffscreenScreenColorEnabled(offscreenIndex: number): boolean {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'getOffscreenScreenColorEnabled'
+      )
+    ) {
+      return false;
+    }
+    return this._userOffscreenScreenColors[offscreenIndex].isOverridden;
+  }
+
+  /**
+   * Sets the multiply color of the offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   * @param color Multiply color to be set (CubismTextureColor)
+   */
+  public setOffscreenMultiplyColorByTextureColor(
+    offscreenIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenMultiplyColorByTextureColor'
+      )
+    ) {
+      return;
+    }
+    this.setOffscreenMultiplyColorByRGBA(
+      offscreenIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the multiply color of the offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   * @param r Red value of the multiply color to be set
+   * @param g Green value of the multiply color to be set
+   * @param b Blue value of the multiply color to be set
+   * @param a Alpha value of the multiply color to be set
+   */
+  public setOffscreenMultiplyColorByRGBA(
+    offscreenIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenMultiplyColorByRGBA'
+      )
+    ) {
+      return;
+    }
+    this._userOffscreenMultiplyColors[offscreenIndex].color.r = r;
+    this._userOffscreenMultiplyColors[offscreenIndex].color.g = g;
+    this._userOffscreenMultiplyColors[offscreenIndex].color.b = b;
+    this._userOffscreenMultiplyColors[offscreenIndex].color.a = a;
+  }
+
+  /**
+   * Returns the multiply color from the list of offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   *
+   * @return Multiply color (CubismTextureColor)
+   */
+  public getOffscreenMultiplyColor(offscreenIndex: number): CubismTextureColor {
+    if (
+      !this.isValidOffscreenIndex(offscreenIndex, 'getOffscreenMultiplyColor')
+    ) {
+      return new CubismTextureColor(1.0, 1.0, 1.0, 1.0); // Default offscreen multiply color
+    }
+    if (
+      this.getMultiplyColorEnabled() ||
+      this.getOffscreenMultiplyColorEnabled(offscreenIndex)
+    ) {
+      return this._userOffscreenMultiplyColors[offscreenIndex].color;
+    }
+    return this._model.getOffscreenMultiplyColor(offscreenIndex);
+  }
+
+  /**
+   * Sets the screen color of the offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   * @param color Screen color to be set (CubismTextureColor)
+   */
+  public setOffscreenScreenColorByTextureColor(
+    offscreenIndex: number,
+    color: CubismTextureColor
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenScreenColorByTextureColor'
+      )
+    ) {
+      return;
+    }
+    this.setOffscreenScreenColorByRGBA(
+      offscreenIndex,
+      color.r,
+      color.g,
+      color.b,
+      color.a
+    );
+  }
+
+  /**
+   * Sets the screen color of the offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   * @param r Red value of the screen color to be set
+   * @param g Green value of the screen color to be set
+   * @param b Blue value of the screen color to be set
+   * @param a Alpha value of the screen color to be set
+   */
+  public setOffscreenScreenColorByRGBA(
+    offscreenIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number = 1.0
+  ): void {
+    if (
+      !this.isValidOffscreenIndex(
+        offscreenIndex,
+        'setOffscreenScreenColorByRGBA'
+      )
+    ) {
+      return;
+    }
+    this._userOffscreenScreenColors[offscreenIndex].color.r = r;
+    this._userOffscreenScreenColors[offscreenIndex].color.g = g;
+    this._userOffscreenScreenColors[offscreenIndex].color.b = b;
+    this._userOffscreenScreenColors[offscreenIndex].color.a = a;
+  }
+
+  /**
+   * Returns the screen color from the list of offscreen.
+   *
+   * @param offscreenIndex Offsscreen index
+   *
+   * @return Screen color (CubismTextureColor)
+   */
+  public getOffscreenScreenColor(offscreenIndex: number): CubismTextureColor {
+    if (
+      !this.isValidOffscreenIndex(offscreenIndex, 'getOffscreenScreenColor')
+    ) {
+      return new CubismTextureColor(0.0, 0.0, 0.0, 1.0); // Default offscreen screen color
+    }
+    if (
+      this.getScreenColorEnabled() ||
+      this.getOffscreenScreenColorEnabled(offscreenIndex)
+    ) {
+      return this._userOffscreenScreenColors[offscreenIndex].color;
+    }
+    return this._model.getOffscreenScreenColor(offscreenIndex);
+  }
+
+  /**
+   * Sets the part color with hierarchical propagation (internal method)
+   */
+  private setPartColor(
+    partIndex: number,
+    r: number,
+    g: number,
+    b: number,
+    a: number,
+    partColors: Array<ColorData>,
+    drawableColors: Array<ColorData>,
+    offscreenColors: Array<ColorData>
+  ): void {
+    partColors[partIndex].color.r = r;
+    partColors[partIndex].color.g = g;
+    partColors[partIndex].color.b = b;
+    partColors[partIndex].color.a = a;
+
+    if (partColors[partIndex].isOverridden) {
+      const offscreenIndices = this._model.getPartOffscreenIndices();
+      const offscreenIndex = offscreenIndices[partIndex];
+      if (offscreenIndex == NoOffscreenIndex) {
+        // If no offscreen buffer is attached, the effect is applied to the children.
+        const partsHierarchy = this._model.getPartsHierarchy();
+        if (partsHierarchy && partsHierarchy[partIndex]) {
+          for (let i = 0; i < partsHierarchy[partIndex].objects.length; ++i) {
+            const objectInfo = partsHierarchy[partIndex].objects[i];
+            if (
+              objectInfo.objectType ===
+              CubismModelObjectType.CubismModelObjectType_Drawable
+            ) {
+              const drawableIndex = objectInfo.objectIndex;
+              drawableColors[drawableIndex].color.r = r;
+              drawableColors[drawableIndex].color.g = g;
+              drawableColors[drawableIndex].color.b = b;
+              drawableColors[drawableIndex].color.a = a;
+            } else {
+              const childPartIndex = objectInfo.objectIndex;
+              this.setPartColor(
+                childPartIndex,
+                r,
+                g,
+                b,
+                a,
+                partColors,
+                drawableColors,
+                offscreenColors
+              );
+            }
+          }
+        }
+      } else {
+        // If an offscreen buffer is attached, only that offscreen buffer is affected.
+        offscreenColors[offscreenIndex].color.r = r;
+        offscreenColors[offscreenIndex].color.g = g;
+        offscreenColors[offscreenIndex].color.b = b;
+        offscreenColors[offscreenIndex].color.a = a;
+      }
+    }
+  }
+
+  /**
+   * Sets the part color enabled flag with hierarchical propagation (internal method)
+   */
+  private setPartColorEnabled(
+    partIndex: number,
+    value: boolean,
+    partColors: Array<ColorData>,
+    drawableColors: Array<ColorData>,
+    offscreenColors: Array<ColorData>
+  ): void {
+    partColors[partIndex].isOverridden = value;
+
+    const offscreenIndices = this._model.getPartOffscreenIndices();
+    const offscreenIndex = offscreenIndices[partIndex];
+    if (offscreenIndex == NoOffscreenIndex) {
+      // If no offscreen buffer is attached, the effect is applied to the children.
+      const partsHierarchy = this._model.getPartsHierarchy();
+      if (partsHierarchy && partsHierarchy[partIndex]) {
+        for (let i = 0; i < partsHierarchy[partIndex].objects.length; ++i) {
+          const objectInfo = partsHierarchy[partIndex].objects[i];
+          if (
+            objectInfo.objectType ===
+            CubismModelObjectType.CubismModelObjectType_Drawable
+          ) {
+            const drawableIndex = objectInfo.objectIndex;
+            drawableColors[drawableIndex].isOverridden = value;
+            if (value) {
+              drawableColors[drawableIndex].color.r =
+                partColors[partIndex].color.r;
+              drawableColors[drawableIndex].color.g =
+                partColors[partIndex].color.g;
+              drawableColors[drawableIndex].color.b =
+                partColors[partIndex].color.b;
+              drawableColors[drawableIndex].color.a =
+                partColors[partIndex].color.a;
+            }
+          } else {
+            const childPartIndex = objectInfo.objectIndex;
+            if (value) {
+              partColors[childPartIndex].color.r =
+                partColors[partIndex].color.r;
+              partColors[childPartIndex].color.g =
+                partColors[partIndex].color.g;
+              partColors[childPartIndex].color.b =
+                partColors[partIndex].color.b;
+              partColors[childPartIndex].color.a =
+                partColors[partIndex].color.a;
+            }
+            this.setPartColorEnabled(
+              childPartIndex,
+              value,
+              partColors,
+              drawableColors,
+              offscreenColors
+            );
+          }
+        }
+      }
+    } else {
+      // If an offscreen buffer is attached, only that offscreen buffer is affected.
+      offscreenColors[offscreenIndex].isOverridden = value;
+      if (value) {
+        offscreenColors[offscreenIndex].color.r = partColors[partIndex].color.r;
+        offscreenColors[offscreenIndex].color.g = partColors[partIndex].color.g;
+        offscreenColors[offscreenIndex].color.b = partColors[partIndex].color.b;
+        offscreenColors[offscreenIndex].color.a = partColors[partIndex].color.a;
+      }
+    }
+  }
+}

--- a/src/model/cubismusermodel.ts
+++ b/src/model/cubismusermodel.ts
@@ -93,19 +93,6 @@ export class CubismUserModel {
   }
 
   /**
-   * 加速度の情報を設定する
-   *
-   * @param x X軸方向の加速度
-   * @param y Y軸方向の加速度
-   * @param z Z軸方向の加速度
-   */
-  public setAcceleration(x: number, y: number, z: number): void {
-    this._accelerationX = x;
-    this._accelerationY = y;
-    this._accelerationZ = z;
-  }
-
-  /**
    * モデル行列を取得する
    * @return モデル行列
    */
@@ -450,13 +437,6 @@ export class CubismUserModel {
     this._initialized = false;
     this._updating = false;
     this._opacity = 1.0;
-    this._lipsync = true;
-    this._lastLipSyncValue = 0.0;
-    this._dragX = 0.0;
-    this._dragY = 0.0;
-    this._accelerationX = 0.0;
-    this._accelerationY = 0.0;
-    this._accelerationZ = 0.0;
     this._mocConsistency = false;
     this._debugMode = false;
     this._renderer = null;
@@ -525,13 +505,6 @@ export class CubismUserModel {
   protected _initialized: boolean; // 初期化されたかどうか
   protected _updating: boolean; // 更新されたかどうか
   protected _opacity: number; // 不透明度
-  protected _lipsync: boolean; // リップシンクするかどうか
-  protected _lastLipSyncValue: number; // 最後のリップシンクの制御地
-  protected _dragX: number; // マウスドラッグのX位置
-  protected _dragY: number; // マウスドラッグのY位置
-  protected _accelerationX: number; // X軸方向の加速度
-  protected _accelerationY: number; // Y軸方向の加速度
-  protected _accelerationZ: number; // Z軸方向の加速度
   protected _mocConsistency: boolean; // MOC3整合性検証するかどうか
   protected _motionConsistency: boolean; // motion3.json整合性検証するかどうか
   protected _debugMode: boolean; // デバッグモードかどうか

--- a/src/motion/cubismbreathupdater.ts
+++ b/src/motion/cubismbreathupdater.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismBreath } from '../effect/cubismbreath';
+
+/**
+ * Updater for breath effects.
+ * Handles the management of breath animation through the CubismBreath class.
+ */
+export class CubismBreathUpdater extends ICubismUpdater {
+  private _breath: CubismBreath;
+
+  /**
+   * Constructor
+   *
+   * @param breath CubismBreath reference
+   */
+  constructor(breath: CubismBreath);
+
+  /**
+   * Constructor
+   *
+   * @param breath CubismBreath reference
+   * @param executionOrder Order of operations
+   */
+  constructor(breath: CubismBreath, executionOrder: number);
+
+  constructor(breath: CubismBreath, executionOrder?: number) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_Breath);
+    this._breath = breath;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    this._breath.updateParameters(model, deltaTimeSeconds);
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismbreathupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismBreathUpdater = $.CubismBreathUpdater;
+  export type CubismBreathUpdater = $.CubismBreathUpdater;
+}

--- a/src/motion/cubismexpressionmotion.ts
+++ b/src/motion/cubismexpressionmotion.ts
@@ -124,10 +124,6 @@ export class CubismExpressionMotion extends ACubismMotion {
       return;
     }
 
-    // CubismExpressionMotion._fadeWeight は廃止予定です。
-    // 互換性のために処理は残りますが、実際には使用しておりません。
-    this._fadeWeight = this.updateFadeWeight(motionQueueEntry, userTimeSeconds);
-
     // モデルに適用する値を計算
     for (let i = 0; i < expressionParameterValues.length; ++i) {
       const expressionParameterValue = expressionParameterValues[i];
@@ -237,21 +233,6 @@ export class CubismExpressionMotion extends ACubismMotion {
     return this._parameters;
   }
 
-  /**
-   * @brief 表情のフェードの値を取得
-   *
-   * 現在の表情のフェードのウェイト値を取得する
-   *
-   * @return 表情のフェードのウェイト値
-   *
-   * @deprecated CubismExpressionMotion.fadeWeightが削除予定のため非推奨。
-   * CubismExpressionMotionManager.getFadeWeight(index: number): number を使用してください。
-   * @see CubismExpressionMotionManager#getFadeWeight(index: number)
-   */
-  public getFadeWeight() {
-    return this._fadeWeight;
-  }
-
   protected parse(buffer: ArrayBuffer, size: number) {
     const json: CubismJson = CubismJson.create(buffer, size);
     if (!json) {
@@ -346,17 +327,9 @@ export class CubismExpressionMotion extends ACubismMotion {
   protected constructor() {
     super();
     this._parameters = new Array<ExpressionParameter>();
-    this._fadeWeight = 0.0;
   }
 
   private _parameters: Array<ExpressionParameter>; // 表情のパラメータ情報リスト
-
-  /**
-   * 表情の現在のウェイト
-   *
-   * @deprecated 不具合を引き起こす要因となるため非推奨。
-   */
-  private _fadeWeight: number;
 }
 
 /**

--- a/src/motion/cubismexpressionmotionmanager.ts
+++ b/src/motion/cubismexpressionmotionmanager.ts
@@ -8,14 +8,9 @@
 import { CubismId, CubismIdHandle } from '../id/cubismid';
 import { LogLevel, csmDelete } from '../live2dcubismframework';
 import { CubismModel } from '../model/cubismmodel';
-import { ACubismMotion } from './acubismmotion';
 import { CubismExpressionMotion } from './cubismexpressionmotion';
 import { CubismMotionQueueEntry } from './cubismmotionqueueentry';
-import {
-  CubismMotionQueueEntryHandle,
-  CubismMotionQueueManager
-} from './cubismmotionqueuemanager';
-import { CubismLogInfo } from '../utils/cubismdebug';
+import { CubismMotionQueueManager } from './cubismmotionqueuemanager';
 
 /**
  * @brief パラメータに適用する表情の値を持たせる構造体
@@ -38,8 +33,6 @@ export class CubismExpressionMotionManager extends CubismMotionQueueManager {
    */
   public constructor() {
     super();
-    this._currentPriority = 0;
-    this._reservePriority = 0;
     this._expressionParameterValues = new Array<ExpressionParameterValue>();
     this._fadeWeights = new Array<number>();
   }
@@ -57,40 +50,6 @@ export class CubismExpressionMotionManager extends CubismMotionQueueManager {
       csmDelete(this._fadeWeights);
       this._fadeWeights = null;
     }
-  }
-
-  /**
-   * @deprecated
-   * ExpressionではPriorityを使用していないため、この関数は非推奨となりました。
-   *
-   * @brief 再生中のモーションの優先度の取得
-   *
-   * 再生中のモーションの優先度を取得する。
-   *
-   * @return モーションの優先度
-   */
-  public getCurrentPriority(): number {
-    CubismLogInfo(
-      'CubismExpressionMotionManager.getCurrentPriority() is deprecated because a priority value is not actually used during expression motion playback.'
-    );
-    return this._currentPriority;
-  }
-
-  /**
-   * @deprecated
-   * ExpressionではPriorityを使用していないため、この関数は非推奨となりました。
-   *
-   * @brief 予約中のモーションの優先度の取得
-   *
-   * 予約中のモーションの優先度を取得する。
-   *
-   * @return  モーションの優先度
-   */
-  public getReservePriority(): number {
-    CubismLogInfo(
-      'CubismExpressionMotionManager.getReservePriority() is deprecated because a priority value is not actually used during expression motion playback.'
-    );
-    return this._reservePriority;
   }
 
   /**
@@ -133,53 +92,6 @@ export class CubismExpressionMotionManager extends CubismMotionQueueManager {
     }
 
     this._fadeWeights[index] = expressionFadeWeight;
-  }
-
-  /**
-   * @deprecated
-   * ExpressionではPriorityを使用していないため、この関数は非推奨となりました。
-   *
-   * @brief 予約中のモーションの優先度の設定
-   *
-   * 予約中のモーションの優先度を設定する。
-   *
-   * @param[in]   priority     優先度
-   */
-  public setReservePriority(priority: number) {
-    CubismLogInfo(
-      'CubismExpressionMotionManager.setReservePriority() is deprecated because a priority value is not actually used during expression motion playback.'
-    );
-    this._reservePriority = priority;
-  }
-
-  /**
-   * @deprecated
-   * ExpressionではPriorityを使用していないため、この関数は非推奨となりました。
-   * CubismExpressionMotionManager.startMotion() を使用してください。
-   *
-   * @brief 優先度を設定してモーションの開始
-   *
-   * 優先度を設定してモーションを開始する。
-   *
-   * @param[in]   motion          モーション
-   * @param[in]   autoDelete      再生が終了したモーションのインスタンスを削除するならtrue
-   * @param[in]   priority        優先度
-   * @return                      開始したモーションの識別番号を返す。個別のモーションが終了したか否かを判定するIsFinished()の引数で使用する。開始できない時は「-1」
-   */
-  public startMotionPriority(
-    motion: ACubismMotion,
-    autoDelete: boolean,
-    priority: number
-  ): CubismMotionQueueEntryHandle {
-    CubismLogInfo(
-      'CubismExpressionMotionManager.startMotionPriority() is deprecated because a priority value is not actually used during expression motion playback.'
-    );
-    if (priority == this.getReservePriority()) {
-      this.setReservePriority(0);
-    }
-    this._currentPriority = priority;
-
-    return this.startMotion(motion, autoDelete);
   }
 
   /**
@@ -356,8 +268,6 @@ export class CubismExpressionMotionManager extends CubismMotionQueueManager {
 
   private _expressionParameterValues: Array<ExpressionParameterValue>; ///< モデルに適用する各パラメータの値
   private _fadeWeights: Array<number>; ///< 再生中の表情のウェイト
-  private _currentPriority: number; ///< @deprecated 現在再生中のモーションの優先度。Expressionでは使用しないため非推奨。
-  private _reservePriority: number; ///< @deprecated 再生予定のモーションの優先度。再生中は0になる。モーションファイルを別スレッドで読み込むときの機能。Expressionでは使用しないため非推奨。
   private _startExpressionTime: number; ///< 表情の再生開始時刻
 }
 

--- a/src/motion/cubismexpressionupdater.ts
+++ b/src/motion/cubismexpressionupdater.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismExpressionMotionManager } from './cubismexpressionmotionmanager';
+
+/**
+ * Updater for expression effects.
+ * Handles the management of expression motion through the CubismExpressionMotionManager.
+ */
+export class CubismExpressionUpdater extends ICubismUpdater {
+  private _expressionManager: CubismExpressionMotionManager;
+
+  /**
+   * Constructor
+   *
+   * @param expressionManager CubismExpressionMotionManager reference
+   */
+  constructor(expressionManager: CubismExpressionMotionManager);
+
+  /**
+   * Constructor
+   *
+   * @param expressionManager CubismExpressionMotionManager reference
+   * @param executionOrder Order of operations
+   */
+  constructor(
+    expressionManager: CubismExpressionMotionManager,
+    executionOrder: number
+  );
+
+  constructor(
+    expressionManager: CubismExpressionMotionManager,
+    executionOrder?: number
+  ) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_Expression);
+    this._expressionManager = expressionManager;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    this._expressionManager.updateMotion(model, deltaTimeSeconds);
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismexpressionupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismExpressionUpdater = $.CubismExpressionUpdater;
+  export type CubismExpressionUpdater = $.CubismExpressionUpdater;
+}

--- a/src/motion/cubismeyeblinkupdater.ts
+++ b/src/motion/cubismeyeblinkupdater.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismEyeBlink } from '../effect/cubismeyeblink';
+
+/**
+ * Updater for eye blink effects.
+ * Handles the management of eye blink animation through the CubismEyeBlink class.
+ */
+export class CubismEyeBlinkUpdater extends ICubismUpdater {
+  private _motionUpdated: () => boolean;
+  private _eyeBlink: CubismEyeBlink;
+
+  /**
+   * Constructor
+   *
+   * @param motionUpdated Motion update flag reference
+   * @param eyeBlink CubismEyeBlink reference
+   */
+  constructor(motionUpdated: () => boolean, eyeBlink: CubismEyeBlink);
+
+  /**
+   * Constructor
+   *
+   * @param motionUpdated Motion update flag reference
+   * @param eyeBlink CubismEyeBlink reference
+   * @param executionOrder Order of operations
+   */
+  constructor(
+    motionUpdated: () => boolean,
+    eyeBlink: CubismEyeBlink,
+    executionOrder: number
+  );
+
+  constructor(
+    motionUpdated: () => boolean,
+    eyeBlink: CubismEyeBlink,
+    executionOrder?: number
+  ) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_EyeBlink);
+    this._motionUpdated = motionUpdated;
+    this._eyeBlink = eyeBlink;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    if (!this._motionUpdated()) {
+      // メインモーションの更新がないとき
+      // 目パチ
+      this._eyeBlink.updateParameters(model, deltaTimeSeconds);
+    }
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismeyeblinkupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismEyeBlinkUpdater = $.CubismEyeBlinkUpdater;
+  export type CubismEyeBlinkUpdater = $.CubismEyeBlinkUpdater;
+}

--- a/src/motion/cubismlipsyncupdater.ts
+++ b/src/motion/cubismlipsyncupdater.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismIdHandle } from '../id/cubismid';
+import { IParameterProvider } from './iparameterprovider';
+
+/**
+ * Updater for lip sync effects.
+ * Handles the management of lip sync animation through parameter providers.
+ */
+export class CubismLipSyncUpdater extends ICubismUpdater {
+  private _lipSyncIds: Array<CubismIdHandle>;
+  private _audioProvider: IParameterProvider | null;
+
+  /**
+   * Constructor
+   *
+   * @param lipSyncIds Array of lip sync parameter IDs
+   * @param audioProvider Audio parameter provider
+   */
+  constructor(
+    lipSyncIds: Array<CubismIdHandle>,
+    audioProvider: IParameterProvider | null
+  );
+
+  /**
+   * Constructor
+   *
+   * @param lipSyncIds Array of lip sync parameter IDs
+   * @param audioProvider Audio parameter provider
+   * @param executionOrder Order of operations
+   */
+  constructor(
+    lipSyncIds: Array<CubismIdHandle>,
+    audioProvider: IParameterProvider | null,
+    executionOrder: number
+  );
+
+  constructor(
+    lipSyncIds: Array<CubismIdHandle>,
+    audioProvider: IParameterProvider | null,
+    executionOrder?: number
+  ) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_LipSync);
+    this._lipSyncIds = [...lipSyncIds]; // Copy array
+    this._audioProvider = audioProvider;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    if (this._audioProvider) {
+      const updateSuccessful = this._audioProvider.update(deltaTimeSeconds);
+      if (updateSuccessful) {
+        const lipSyncValue = this._audioProvider.getParameter();
+
+        // Apply lip sync value to all registered parameters
+        for (let i = 0; i < this._lipSyncIds.length; i++) {
+          model.addParameterValueById(this._lipSyncIds[i], lipSyncValue);
+        }
+      }
+    }
+  }
+
+  /**
+   * Set audio parameter provider.
+   *
+   * @param audioProvider Audio parameter provider to set
+   */
+  setAudioProvider(audioProvider: IParameterProvider | null): void {
+    this._audioProvider = audioProvider;
+  }
+
+  /**
+   * Get audio parameter provider.
+   *
+   * @return Current audio parameter provider
+   */
+  getAudioProvider(): IParameterProvider | null {
+    return this._audioProvider;
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismlipsyncupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismLipSyncUpdater = $.CubismLipSyncUpdater;
+  export type CubismLipSyncUpdater = $.CubismLipSyncUpdater;
+}

--- a/src/motion/cubismlookupdater.ts
+++ b/src/motion/cubismlookupdater.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismTargetPoint } from '../math/cubismtargetpoint';
+import { CubismLook } from '../effect/cubismlook';
+
+/**
+ * Updater for look effects.
+ * Handles the management of dragging motion through the MotionQueueManager.
+ */
+export class CubismLookUpdater extends ICubismUpdater {
+  private _look: CubismLook;
+  private _dragManager: CubismTargetPoint;
+
+  /**
+   * Constructor
+   *
+   * @param look CubismLook reference
+   * @param dragManager CubismTargetPoint reference
+   */
+  constructor(look: CubismLook, dragManager: CubismTargetPoint);
+
+  /**
+   * Constructor
+   *
+   * @param look CubismLook reference
+   * @param dragManager CubismTargetPoint reference
+   * @param executionOrder Order of operations
+   */
+  constructor(
+    look: CubismLook,
+    dragManager: CubismTargetPoint,
+    executionOrder: number
+  );
+
+  constructor(
+    look: CubismLook,
+    dragManager: CubismTargetPoint,
+    executionOrder?: number
+  ) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_Drag);
+    this._look = look;
+    this._dragManager = dragManager;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    this._dragManager.update(deltaTimeSeconds);
+    const dragX = this._dragManager.getX();
+    const dragY = this._dragManager.getY();
+
+    this._look.updateParameters(model, dragX, dragY);
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismlookupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismLookUpdater = $.CubismLookUpdater;
+  export type CubismLookUpdater = $.CubismLookUpdater;
+}

--- a/src/motion/cubismmotion.ts
+++ b/src/motion/cubismmotion.ts
@@ -653,53 +653,6 @@ export class CubismMotion extends ACubismMotion {
   }
 
   /**
-   * ループ情報の設定
-   * @param loop ループ情報
-   */
-  public setIsLoop(loop: boolean): void {
-    CubismLogWarning(
-      'setIsLoop() is a deprecated function. Please use setLoop().'
-    );
-    this._isLoop = loop;
-  }
-
-  /**
-   * ループ情報の取得
-   * @return true ループする
-   * @return false ループしない
-   */
-  public isLoop(): boolean {
-    CubismLogWarning(
-      'isLoop() is a deprecated function. Please use getLoop().'
-    );
-    return this._isLoop;
-  }
-
-  /**
-   * ループ時のフェードイン情報の設定
-   * @param loopFadeIn  ループ時のフェードイン情報
-   */
-  public setIsLoopFadeIn(loopFadeIn: boolean): void {
-    CubismLogWarning(
-      'setIsLoopFadeIn() is a deprecated function. Please use setLoopFadeIn().'
-    );
-    this._isLoopFadeIn = loopFadeIn;
-  }
-
-  /**
-   * ループ時のフェードイン情報の取得
-   *
-   * @return  true    する
-   * @return  false   しない
-   */
-  public isLoopFadeIn(): boolean {
-    CubismLogWarning(
-      'isLoopFadeIn() is a deprecated function. Please use getLoopFadeIn().'
-    );
-    return this._isLoopFadeIn;
-  }
-
-  /**
    * Sets the version of the Motion Behavior.
    *
    * @param Specifies the version of the Motion Behavior.

--- a/src/motion/cubismphysicsupdater.ts
+++ b/src/motion/cubismphysicsupdater.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismPhysics } from '../physics/cubismphysics';
+
+/**
+ * Updater for physics effects.
+ * Handles the management of physics simulation through the CubismPhysics class.
+ */
+export class CubismPhysicsUpdater extends ICubismUpdater {
+  private _physics: CubismPhysics;
+
+  /**
+   * Constructor
+   *
+   * @param physics CubismPhysics reference
+   */
+  constructor(physics: CubismPhysics);
+
+  /**
+   * Constructor
+   *
+   * @param physics CubismPhysics reference
+   * @param executionOrder Order of operations
+   */
+  constructor(physics: CubismPhysics, executionOrder: number);
+
+  constructor(physics: CubismPhysics, executionOrder?: number) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_Physics);
+    this._physics = physics;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    this._physics.evaluate(model, deltaTimeSeconds);
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismphysicsupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismPhysicsUpdater = $.CubismPhysicsUpdater;
+  export type CubismPhysicsUpdater = $.CubismPhysicsUpdater;
+}

--- a/src/motion/cubismposeupdater.ts
+++ b/src/motion/cubismposeupdater.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, CubismUpdateOrder } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+import { CubismPose } from '../effect/cubismpose';
+
+/**
+ * Updater for pose effects.
+ * Handles the management of pose animation through the CubismPose class.
+ */
+export class CubismPoseUpdater extends ICubismUpdater {
+  private _pose: CubismPose;
+
+  /**
+   * Constructor
+   *
+   * @param pose CubismPose reference
+   */
+  constructor(pose: CubismPose);
+
+  /**
+   * Constructor
+   *
+   * @param pose CubismPose reference
+   * @param executionOrder Order of operations
+   */
+  constructor(pose: CubismPose, executionOrder: number);
+
+  constructor(pose: CubismPose, executionOrder?: number) {
+    super(executionOrder ?? CubismUpdateOrder.CubismUpdateOrder_Pose);
+    this._pose = pose;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    this._pose.updateParameters(model, deltaTimeSeconds);
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismposeupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismPoseUpdater = $.CubismPoseUpdater;
+  export type CubismPoseUpdater = $.CubismPoseUpdater;
+}

--- a/src/motion/cubismupdatescheduler.ts
+++ b/src/motion/cubismupdatescheduler.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { ICubismUpdater, ICubismUpdaterChangeListener } from './icubismupdater';
+import { CubismModel } from '../model/cubismmodel';
+
+/**
+ * Scheduler for managing and updating ICubismUpdater instances.
+ * Handles the management of update order and execution through a sorted list.
+ */
+export class CubismUpdateScheduler implements ICubismUpdaterChangeListener {
+  private _cubismUpdatableList: ICubismUpdater[];
+  private _needsSort: boolean;
+
+  /**
+   * Constructor
+   */
+  constructor() {
+    this._cubismUpdatableList = [];
+    this._needsSort = false;
+  }
+
+  /**
+   * Destructor equivalent - releases all updaters and removes listeners
+   */
+  public release(): void {
+    // Remove all listeners before clearing
+    for (const updater of this._cubismUpdatableList) {
+      if (updater) {
+        updater.removeChangeListener(this);
+      }
+    }
+    // Clear the list - in TypeScript we don't need to manually delete objects
+    // as they will be garbage collected when no longer referenced
+    this._cubismUpdatableList.length = 0;
+  }
+
+  /**
+   * Adds ICubismUpdater to the update list.
+   * The list will be automatically sorted by execution order before the next update.
+   *
+   * @param updatable The ICubismUpdater instance to be added.
+   */
+  public addUpdatableList(updatable: ICubismUpdater): void {
+    if (!updatable) {
+      return;
+    }
+
+    // Check for duplicate registration
+    if (this.hasUpdatable(updatable)) {
+      return; // Already exists, skip adding
+    }
+
+    this._cubismUpdatableList.push(updatable);
+    updatable.addChangeListener(this);
+    this._needsSort = true;
+  }
+
+  /**
+   * Removes ICubismUpdater from the update list.
+   *
+   * @param updatable The ICubismUpdater instance to be removed.
+   * @return true if the updater was found and removed, false otherwise.
+   */
+  public removeUpdatableList(updatable: ICubismUpdater): boolean {
+    if (!updatable) {
+      return false;
+    }
+
+    const index = this._cubismUpdatableList.indexOf(updatable);
+    if (index >= 0) {
+      this._cubismUpdatableList.splice(index, 1);
+      updatable.removeChangeListener(this);
+      // Note: removal doesn't require re-sorting
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Sorts the update list using the ICubismUpdater sort function.
+   */
+  public sortUpdatableList(): void {
+    this._cubismUpdatableList.sort(ICubismUpdater.sortFunction);
+    this._needsSort = false;
+  }
+
+  /**
+   * Updates every element in the list.
+   * The list is automatically sorted by execution order before execution.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  public onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void {
+    if (!model) {
+      return;
+    }
+
+    // Automatically sort if needed to ensure execution order
+    if (this._needsSort) {
+      this.sortUpdatableList();
+    }
+
+    for (let i = 0; i < this._cubismUpdatableList.length; ++i) {
+      const updater = this._cubismUpdatableList[i];
+      if (updater) {
+        updater.onLateUpdate(model, deltaTimeSeconds);
+      }
+    }
+  }
+
+  /**
+   * Gets the number of updaters in the list.
+   *
+   * @return Number of updaters
+   */
+  public getUpdatableCount(): number {
+    return this._cubismUpdatableList.length;
+  }
+
+  /**
+   * Gets the updater at the specified index.
+   *
+   * @param index Index of the updater to retrieve
+   * @return The updater at the specified index, or null if index is out of bounds
+   */
+  public getUpdatable(index: number): ICubismUpdater | null {
+    if (index < 0 || index >= this._cubismUpdatableList.length) {
+      return null;
+    }
+    return this._cubismUpdatableList[index];
+  }
+
+  /**
+   * Checks if the specified updater exists in the list.
+   *
+   * @param updatable The updater to check for
+   * @return true if the updater exists in the list, false otherwise
+   */
+  public hasUpdatable(updatable: ICubismUpdater): boolean {
+    return this._cubismUpdatableList.indexOf(updatable) >= 0;
+  }
+
+  /**
+   * Clears all updaters from the list.
+   */
+  public clearUpdatableList(): void {
+    // Remove listeners before clearing
+    for (const updater of this._cubismUpdatableList) {
+      if (updater) {
+        updater.removeChangeListener(this);
+      }
+    }
+    this._cubismUpdatableList.length = 0;
+    this._needsSort = false;
+  }
+
+  /**
+   * Called when an updater's execution order has changed.
+   * Marks the list for re-sorting.
+   *
+   * @param updater The updater that was changed
+   */
+  public onUpdaterChanged(updater: ICubismUpdater): void {
+    this._needsSort = true;
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './cubismupdatescheduler';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const CubismUpdateScheduler = $.CubismUpdateScheduler;
+  export type CubismUpdateScheduler = $.CubismUpdateScheduler;
+}

--- a/src/motion/icubismupdater.ts
+++ b/src/motion/icubismupdater.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+import { CubismModel } from '../model/cubismmodel';
+
+/**
+ * Interface for listening to ICubismUpdater changes.
+ */
+export interface ICubismUpdaterChangeListener {
+  /**
+   * Called when an updater's execution order has changed.
+   *
+   * @param updater The updater that was changed
+   */
+  onUpdaterChanged(updater: ICubismUpdater): void;
+}
+
+export enum CubismUpdateOrder {
+  CubismUpdateOrder_EyeBlink = 200,
+  CubismUpdateOrder_Expression = 300,
+  CubismUpdateOrder_Drag = 400,
+  CubismUpdateOrder_Breath = 500,
+  CubismUpdateOrder_Physics = 600,
+  CubismUpdateOrder_LipSync = 700,
+  CubismUpdateOrder_Pose = 800,
+  CubismUpdateOrder_Max = Number.MAX_SAFE_INTEGER
+}
+
+/**
+ * Abstract base class for motions.<br>
+ * Handles the management of motion playback through the CubismUpdateScheduler.
+ */
+export abstract class ICubismUpdater {
+  /**
+   * Comparison function used when sorting ICubismUpdater objects.
+   *
+   * @param left The first ICubismUpdater object to be compared.
+   * @param right The second ICubismUpdater object to be compared.
+   *
+   * @return negative if left should be placed before right,
+   *         positive if right should be placed before left,
+   *         zero if they are equal.
+   */
+  static sortFunction(left: ICubismUpdater, right: ICubismUpdater): number {
+    if (!left || !right) {
+      if (!left && !right) return 0;
+      if (!left) return 1; // null/undefined elements go to end
+      if (!right) return -1;
+    }
+    return left.getExecutionOrder() - right.getExecutionOrder();
+  }
+
+  private _executionOrder: number;
+  private _changeListeners: ICubismUpdaterChangeListener[] = [];
+
+  /**
+   * Constructor
+   */
+  constructor(executionOrder: number = 0) {
+    this._executionOrder = executionOrder;
+  }
+
+  /**
+   * Update process.
+   *
+   * @param model Model to update
+   * @param deltaTimeSeconds Delta time in seconds.
+   */
+  abstract onLateUpdate(model: CubismModel, deltaTimeSeconds: number): void;
+
+  getExecutionOrder(): number {
+    return this._executionOrder;
+  }
+
+  setExecutionOrder(executionOrder: number): void {
+    if (this._executionOrder !== executionOrder) {
+      this._executionOrder = executionOrder;
+      this.notifyChangeListeners();
+    }
+  }
+
+  /**
+   * Adds a listener to be notified when this updater's properties change.
+   *
+   * @param listener The listener to add
+   */
+  addChangeListener(listener: ICubismUpdaterChangeListener): void {
+    if (listener && this._changeListeners.indexOf(listener) === -1) {
+      this._changeListeners.push(listener);
+    }
+  }
+
+  /**
+   * Removes a listener from the notification list.
+   *
+   * @param listener The listener to remove
+   */
+  removeChangeListener(listener: ICubismUpdaterChangeListener): void {
+    const index = this._changeListeners.indexOf(listener);
+    if (index >= 0) {
+      this._changeListeners.splice(index, 1);
+    }
+  }
+
+  /**
+   * Notifies all registered listeners that this updater has changed.
+   */
+  private notifyChangeListeners(): void {
+    for (const listener of this._changeListeners) {
+      listener.onUpdaterChanged(this);
+    }
+  }
+}
+
+// Namespace definition for compatibility.
+import * as $ from './icubismupdater';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const ICubismUpdater = $.ICubismUpdater;
+  export type ICubismUpdater = $.ICubismUpdater;
+  export type ICubismUpdaterChangeListener = $.ICubismUpdaterChangeListener;
+}

--- a/src/motion/iparameterprovider.ts
+++ b/src/motion/iparameterprovider.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+/**
+ * Interface class for providing parameter values.<br>
+ * Defines the base interface for classes that supply parameter values to the model.
+ */
+export abstract class IParameterProvider {
+  /**
+   * Constructor
+   */
+  constructor() {}
+
+  /**
+   * Update process.
+   *
+   * @param deltaTimeSeconds Delta time in seconds (optional).
+   *
+   * @return true if the update is successful.
+   */
+  abstract update(deltaTimeSeconds?: number): boolean;
+
+  /**
+   * Retrieves the current value of the parameter.
+   *
+   * @return The parameter value as a floating-point number.
+   */
+  abstract getParameter(): number;
+}
+
+// Namespace definition for compatibility.
+import * as $ from './iparameterprovider';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Live2DCubismFramework {
+  export const IParameterProvider = $.IParameterProvider;
+  export type IParameterProvider = $.IParameterProvider;
+}

--- a/src/rendering/cubismshader_webgl.ts
+++ b/src/rendering/cubismshader_webgl.ts
@@ -487,8 +487,11 @@ export class CubismShader_WebGL {
       );
     }
 
-    const multiplyColor: CubismTextureColor = model.getMultiplyColor(index);
-    const screenColor: CubismTextureColor = model.getScreenColor(index);
+    const multiplyAndScreenColor = model.getOverrideMultiplyAndScreenColor();
+    const multiplyColor: CubismTextureColor =
+      multiplyAndScreenColor.getDrawableMultiplyColor(index);
+    const screenColor: CubismTextureColor =
+      multiplyAndScreenColor.getDrawableScreenColor(index);
 
     this.gl.uniform4f(
       shaderSet.uniformBaseColorLocation,
@@ -694,10 +697,11 @@ export class CubismShader_WebGL {
       offscreenOpacity
     );
 
+    const multiplyAndScreenColor = model.getOverrideMultiplyAndScreenColor();
     const multiplyColor: CubismTextureColor =
-      model.getMultiplyColorOffscreen(offscreenIndex);
+      multiplyAndScreenColor.getOffscreenMultiplyColor(offscreenIndex);
     const screenColor: CubismTextureColor =
-      model.getScreenColorOffscreen(offscreenIndex);
+      multiplyAndScreenColor.getOffscreenScreenColor(offscreenIndex);
 
     this.gl.uniform4f(
       shaderSet.uniformBaseColorLocation,
@@ -925,25 +929,6 @@ export class CubismShader_WebGL {
       rect.y * 2.0 - 1.0,
       rect.getRight() * 2.0 - 1.0,
       rect.getBottom() * 2.0 - 1.0
-    );
-
-    const multiplyColor: CubismTextureColor = model.getMultiplyColor(index);
-    const screenColor: CubismTextureColor = model.getScreenColor(index);
-
-    this.gl.uniform4f(
-      shaderSet.uniformMultiplyColorLocation,
-      multiplyColor.r,
-      multiplyColor.g,
-      multiplyColor.b,
-      multiplyColor.a
-    );
-
-    this.gl.uniform4f(
-      shaderSet.uniformScreenColorLocation,
-      screenColor.r,
-      screenColor.g,
-      screenColor.b,
-      screenColor.a
     );
 
     // Blending
@@ -1183,15 +1168,6 @@ export class CubismShader_WebGL {
     this._shaderSets[0].uniformBaseColorLocation = this.gl.getUniformLocation(
       this._shaderSets[0].shaderProgram,
       'u_baseColor'
-    );
-    this._shaderSets[0].uniformMultiplyColorLocation =
-      this.gl.getUniformLocation(
-        this._shaderSets[0].shaderProgram,
-        'u_multiplyColor'
-      );
-    this._shaderSets[0].uniformScreenColorLocation = this.gl.getUniformLocation(
-      this._shaderSets[0].shaderProgram,
-      'u_screenColor'
     );
 
     // 通常（PremultipliedAlpha）


### PR DESCRIPTION
### Added

* Add functionality to change motion calculation order.
* Add `cubismlook` class that implements the target tracking feature.
  * The target tracking feature can now specify parameter IDs through the `Framework`.

### Changed

* Change multiply and screen color functions to separate class with renamed methods.

### Fixed

* Fix unnecessary multiply color and screen color settings in mask drawing.

### Removed

* Remove deprecated functions from CubismMotion:
  * `setIsLoop()` (use `setLoop()` instead)
  * `isLoop()` (use `getLoop()` instead)
  * `setIsLoopFadeIn()` (use `setLoopFadeIn()` instead)
  * `isLoopFadeIn()` (use `getLoopFadeIn()` instead)
* Remove deprecated functions from CubismExpressionMotionManager:
  * `getCurrentPriority()` (priority is not used in expression motion playback)
  * `getReservePriority()` (priority is not used in expression motion playback)
  * `setReservePriority()` (priority is not used in expression motion playback)
  * `startMotionPriority()` (use `startMotion()` instead)
* Remove deprecated fields from CubismExpressionMotionManager:
  * `_currentPriority` (priority is not used in expression motion playback)
  * `_reservePriority` (priority is not used in expression motion playback)
* Remove deprecated function from CubismExpressionMotion:
  * `getFadeWeight()` (use `CubismExpressionMotionManager.getFadeWeight()` instead)
* Remove deprecated field from CubismExpressionMotion:
  * `_fadeWeight` (can cause bugs)
* Remove deprecated functions from CubismModel:
  * `getOverwriteFlagForModelCullings()` (renamed to `getOverrideFlagForModelCullings()`)
  * `setOverwriteFlagForModelCullings()` (renamed to `setOverrideFlagForModelCullings()`)
  * `getOverwriteFlagForDrawableCullings()` (renamed to `getOverrideFlagForDrawableCullings()`)
  * `setOverwriteFlagForDrawableCullings()` (renamed to `setOverrideFlagForDrawableCullings()`)