### PR TITLE
fix: bound strtod() scan to the input length

### DIFF
--- a/src/live2dcubismframework.ts
+++ b/src/live2dcubismframework.ts
@@ -16,7 +16,9 @@ import { Value } from './utils/cubismjson';
 
 export function strtod(s: string, endPtr: string[]): number {
   let index = 0;
-  for (let i = 1; ; i++) {
+  // Bound the scan: once i exceeds s.length, substring clamps and a complete
+  // number never becomes NaN, so an unbounded loop never terminates.
+  for (let i = 1; i <= s.length; i++) {
     const testC: string = s.slice(i - 1, i);
 
     // 指数・マイナスの可能性があるのでスキップする

--- a/src/utils/cubismjson.ts
+++ b/src/utils/cubismjson.ts
@@ -390,8 +390,11 @@ export class CubismJson {
         case '8':
         case '9': {
           const afterString: string[] = new Array(1); // 参照渡しにするため
-          f = strtod(buffer.slice(i), afterString);
-          outEndPos[0] = buffer.indexOf(afterString[0]);
+          const numericSlice = buffer.slice(i);
+          f = strtod(numericSlice, afterString);
+          // afterString[0] が空だと indexOf('') は 0 を返し、パース位置が巻き戻る
+          const remainder = afterString[0] ?? '';
+          outEndPos[0] = i + numericSlice.length - remainder.length;
           return new JsonFloat(f);
         }
         case '"':


### PR DESCRIPTION
## Bug

`strtod()` in `src/live2dcubismframework.ts` scanned with an unbounded loop:

```ts
for (let i = 1; ; i++) {
```

Termination depends on `Number(s.substring(0, i))` becoming `NaN`. Once `i` exceeds `s.length`, `substring` clamps to the full string. A complete valid number never produces `NaN`, so the loop never exits. `Number("") === 0`, so empty / whitespace-only input hangs the same way.

Caller: `CubismJson.parseValue` in `src/utils/cubismjson.ts`. Typical JSON with a trailing `}` often survives; a number at EOF, a numeric document, or trailing whitespace after a number does not.

A second hang remained after bounding the scan: `parseValue` derived `outEndPos` with `buffer.indexOf(afterString[0])`. When `strtod` consumes through end-of-input the remainder is `''`, and `indexOf('')` is always `0`, so parse position rewound.

## Change

1. Bound the scan: `for (let i = 1; i <= s.length; i++)`.
2. Compute `outEndPos` from consumed length instead of `indexOf`:

```ts
const numericSlice = buffer.slice(i);
f = strtod(numericSlice, afterString);
const remainder = afterString[0] ?? '';
outEndPos[0] = i + numericSlice.length - remainder.length;
```

Parse / `endPtr` behavior is otherwise unchanged.

## Repro (Node)

Unbounded `strtod('123', [''])` never returns. Same for `"1.5"`, `"1e10"`, `"-3.2"`, `"1E-4"`, `""`, `"  5  "`. Inputs with a terminator (`"123}"`, `"123,"`, `"123abc"`) already returned.

After the bound-only change, EOF numbers still rewound via `indexOf('')`. Consumed-length `outEndPos` advances to the end of the slice.

## Checks

- eslint on the touched files: clean
- `tsc --noEmit`: pre-existing `Live2DCubismCore` errors on `develop` (Core is not in this repo). No new errors from this change.

Ikati tracking: https://github.com/SweetSophia/ikati/issues/27
Fork review: https://github.com/SweetSophia/CubismWebFramework/pull/1
