### PR TITLE
fix: skip invalid partIndex in clipping child walk

### DIFF
--- a/src/rendering/cubismclippingmanager.ts
+++ b/src/rendering/cubismclippingmanager.ts
@@ -580,8 +580,12 @@ export abstract class CubismClippingManager<
     partIndex: number,
     childDrawableIndexList: Array<number>
   ): void {
-    const childDrawObjects =
-      model.getPartsHierarchy()[partIndex].childDrawObjects;
+    const partsHierarchy = model.getPartsHierarchy();
+    // NoParentIndex is -1; out-of-range indexes must not index the hierarchy.
+    if (partIndex < 0 || partIndex >= partsHierarchy.length) {
+      return;
+    }
+    const childDrawObjects = partsHierarchy[partIndex].childDrawObjects;
     childDrawableIndexList.push(...childDrawObjects.drawableIndices);
 
     for (let i = 0; i < childDrawObjects.offscreenIndices.length; ++i) {

--- a/src/rendering/cubismclippingmanager.ts
+++ b/src/rendering/cubismclippingmanager.ts
@@ -581,8 +581,12 @@ export abstract class CubismClippingManager<
     childDrawableIndexList: Array<number>
   ): void {
     const partsHierarchy = model.getPartsHierarchy();
-    // NoParentIndex is -1; out-of-range indexes must not index the hierarchy.
-    if (partIndex < 0 || partIndex >= partsHierarchy.length) {
+    // NoParentIndex は -1。非整数や範囲外のインデックスでは階層を参照しない。
+    if (
+      !Number.isInteger(partIndex) ||
+      partIndex < 0 ||
+      partIndex >= partsHierarchy.length
+    ) {
       return;
     }
     const childDrawObjects = partsHierarchy[partIndex].childDrawObjects;


### PR DESCRIPTION
## Bug

`getOffscreenChildDrawableIndexList` forwards `model.getOffscreenOwnerIndices()[offscreenIndex]` into `getPartChildDrawableIndexList`.

`NoParentIndex` is `-1` (`src/model/cubismmodel.ts`). In JavaScript `arr[-1]` is `undefined`, not the last element, so this throws:

`TypeError: Cannot read properties of undefined (reading 'childDrawObjects')`

The WebGL renderer already treats `NoParentIndex` as a stop condition. The clipping manager did not.

A non-integer or `NaN` `partIndex` also bypassed a `< 0 || >= length` guard, because both comparisons are false for `NaN` / `0.5`.

## Change

In `getPartChildDrawableIndexList`, return without walking when the index is not a safe hierarchy slot:

```ts
if (
  !Number.isInteger(partIndex) ||
  partIndex < 0 ||
  partIndex >= partsHierarchy.length
) {
  return;
}
```

Valid indexes keep the existing child-drawable collection path.

## Repro

Load a Cubism 5.3+ model whose offscreen `ownerIndices[i] === -1` (or pass any out-of-range `partIndex`) and run mask setup. `calcClippedOffscreenTotalBounds` → `getOffscreenChildDrawableIndexList` → `getPartChildDrawableIndexList` throws.

## Checks

- eslint on the touched file: clean
- `tsc --noEmit`: pre-existing `Live2DCubismCore` errors on `develop`. No new errors from this change.

Ikati tracking: https://github.com/SweetSophia/ikati/issues/27
Fork review: https://github.com/SweetSophia/CubismWebFramework/pull/2
