### PR TITLE
fix: do not delete pooled offscreen GPU objects on release

### DIFF
--- a/src/rendering/cubismoffscreenrendertarget_webgl.ts
+++ b/src/rendering/cubismoffscreenrendertarget_webgl.ts
@@ -204,8 +204,10 @@ export class CubismOffscreenRenderTarget_WebGL extends CubismRenderTarget_WebGL 
   }
 
   public release(): void {
+    const borrowedFromManager = this._webGLOffscreenManager != null;
+
     if (
-      this._webGLOffscreenManager != null &&
+      borrowedFromManager &&
       this._gl != null &&
       this._renderTexture != null
     ) {
@@ -215,12 +217,18 @@ export class CubismOffscreenRenderTarget_WebGL extends CubismRenderTarget_WebGL 
       );
     }
 
-    // Color buffer and framebuffer are borrowed from CubismWebGLOffscreenManager.
-    // The manager owns GPU lifetime (releaseStaleRenderTextures / context teardown).
-    // Deleting them here double-frees the pool slot and can delete previousFramebuffer
-    // when setOffscreenRenderTarget stored it as a fallback.
-    this._colorBuffer = null;
-    this._renderTexture = null;
+    if (borrowedFromManager) {
+      // Color buffer and framebuffer are borrowed from CubismWebGLOffscreenManager.
+      // The manager owns GPU lifetime (releaseStaleRenderTextures / context teardown).
+      // Deleting them here double-frees the pool slot and can delete previousFramebuffer
+      // when setOffscreenRenderTarget stored it as a fallback.
+      this._colorBuffer = null;
+      this._renderTexture = null;
+    } else if (this._gl) {
+      // Inherited createRenderTarget() locally owns the texture/FBO
+      // (_modelRenderTargets). destroyRenderTarget() is the matching owner.
+      this.destroyRenderTarget();
+    }
 
     if (this._webGLOffscreenManager != null) {
       this._webGLOffscreenManager = null;

--- a/src/rendering/cubismoffscreenrendertarget_webgl.ts
+++ b/src/rendering/cubismoffscreenrendertarget_webgl.ts
@@ -215,14 +215,12 @@ export class CubismOffscreenRenderTarget_WebGL extends CubismRenderTarget_WebGL 
       );
     }
 
-    if (this._colorBuffer && this._gl) {
-      this._gl.deleteTexture(this._colorBuffer);
-      this._colorBuffer = null;
-    }
-    if (this._renderTexture && this._gl) {
-      this._gl.deleteFramebuffer(this._renderTexture);
-      this._renderTexture = null;
-    }
+    // Color buffer and framebuffer are borrowed from CubismWebGLOffscreenManager.
+    // The manager owns GPU lifetime (releaseStaleRenderTextures / context teardown).
+    // Deleting them here double-frees the pool slot and can delete previousFramebuffer
+    // when setOffscreenRenderTarget stored it as a fallback.
+    this._colorBuffer = null;
+    this._renderTexture = null;
 
     if (this._webGLOffscreenManager != null) {
       this._webGLOffscreenManager = null;

--- a/src/rendering/cubismrenderer_webgl.ts
+++ b/src/rendering/cubismrenderer_webgl.ts
@@ -741,7 +741,8 @@ export class CubismRenderer_WebGL extends CubismRenderer {
 
     for (let i = 0; i < this._offscreenList.length; i++) {
       if (this._offscreenList[i] != null && this._offscreenList[i].isValid()) {
-        this._offscreenList[i].destroyRenderTarget();
+        // プールから借用した GPU オブジェクトは destroy しない
+        this._offscreenList[i].release();
       }
     }
     this._offscreenList.length = 0;


### PR DESCRIPTION
## Bug

`CubismOffscreenRenderTarget_WebGL` **borrows** `colorBuffer` / `renderTexture` from the singleton `CubismWebGLOffscreenManager` pool. `release()` already returns the slot via `stopUsingRenderTexture()`, then also called:

```ts
this._gl.deleteTexture(this._colorBuffer);
this._gl.deleteFramebuffer(this._renderTexture);
```

The manager still holds those handles and deletes them again in context teardown and `releaseStaleRenderTextures()`. That is a WebGL double-delete. The next borrower of that pool slot gets a deleted texture/FBO.

Extra hazard: on acquire failure, `setOffscreenRenderTarget` stores `previousFramebuffer` in `_renderTexture`. `release()` would then delete the caller's FBO.

Renderer teardown had the same class of bug: `CubismRenderer_WebGL.release()` called `destroyRenderTarget()` on pooled `_offscreenList` entries.

Instances created via inherited `createRenderTarget()` (used by `_modelRenderTargets`) still locally own their texture/FBO and must destroy them.

## Change

`release()` discriminates ownership with `borrowedFromManager = this._webGLOffscreenManager != null`:

- Borrowed (`setOffscreenRenderTarget` / manager pool): `stopUsingRenderTexture`, then null the refs. No `gl.delete*`.
- Locally owned (inherited `createRenderTarget`): `destroyRenderTarget()`.

Renderer teardown of `_offscreenList` now calls `release()` instead of `destroyRenderTarget()`. `_modelRenderTargets`, `_drawableMasks`, and `_offscreenMasks` stay on `destroyRenderTarget()`.

Left `setOffscreenRenderTarget`'s fallback assignment alone (out of this PR's one-bug scope). Flagged in the comment.

## Repro

1. Use a Cubism 5.3+ model with offscreen drawing so the target acquires a pooled container.
2. `release()` the offscreen target (dispose / teardown / size rebuild).
3. Continue rendering or acquire another offscreen of the same size.
4. Deleted-object WebGL errors, and/or a later double-delete when the manager trims stale containers.

## Checks

- eslint on the touched files: clean
- `tsc --noEmit`: pre-existing `Live2DCubismCore` errors on `develop`. No new errors from this change.

Ikati tracking: https://github.com/SweetSophia/ikati/issues/27
Fork review: https://github.com/SweetSophia/CubismWebFramework/pull/3
